### PR TITLE
Implement semantic markup support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -166,6 +166,40 @@ By default, Asciidoctor resolves all `include` directives before converting the 
 $ **asciidoctor -r dita-topic -b dita-topic -S secure _your_file_.adoc**
 ....
 
+[#semantics]
+=== Using semantic markup
+
+Unlike AsciiDoc, DITA provides a number of semantic elements for software components such as file names, commands, or command-line options. To replicate this behavior, the `dita-topic` converter recognizes the following link:https://docs.asciidoctor.org/asciidoc/latest/attributes/role/#assign-roles-to-formatted-inline-elements[roles] assigned to monospace (```) inline text:
+
+[cols="1,1"]
+|===
+| AsciiDoc Role
+| DITA Element
+
+| command
+| `<cmdname>`
+
+| directory
+| `<filepath>`
+
+| filename
+| `<filepath>`
+
+| option
+| `<option>`
+
+| variable
+| `<varname>`
+|===
+
+For example, to describe a file name, use the following AsciiDoc markup:
+
+[source,asciidoc]
+----
+Read the [filename]`/etc/passwd` file to see the complete list of
+available user accounts.
+----
+
 [#warnings]
 == Warnings
 

--- a/lib/dita-topic.rb
+++ b/lib/dita-topic.rb
@@ -38,6 +38,9 @@ class DitaTopic < Asciidoctor::Converter::Base
     # Disable the author line by default:
     @authors_allowed = false
 
+    # Disable semantic markup by default:
+    @semantic_allowed = false
+
     # Enable abstract paragraphs by default:
     @abstracts_allowed = true
 
@@ -54,6 +57,9 @@ class DitaTopic < Asciidoctor::Converter::Base
   def convert_document node
     # Check if the author line is enabled:
     @authors_allowed = true if (node.attr 'dita-topic-authors') == 'on'
+
+    # Check if semantic markup is enabled:
+    @semantic_allowed = true if (node.attr 'dita-topic-semantic') == 'on'
 
     # Check if abstract paragraphs are enabled:
     @abstracts_allowed = false if (node.attr 'dita-topic-abstracts') == 'off'
@@ -450,7 +456,25 @@ class DitaTopic < Asciidoctor::Converter::Base
     when :strong
       %(<b>#{node.text}</b>)
     when :monospaced
-      %(<tt>#{node.text}</tt>)
+      # Check whether semantic markup is enabled:
+      if @semantic_allowed and node.role
+        # Define supported roles:
+        semantic_markup = {
+          'command'   => 'cmdname',
+          'filename'  => 'filepath',
+          'directory' => 'filepath',
+          'option'    => 'option'
+        }
+
+        # Select the appropriate semantic element:
+        element = (semantic_markup.key? node.role) ? semantic_markup[node.role] : 'tt'
+      else
+        # Use the teletype element by default:
+        element = 'tt'
+      end
+
+      # Return the result:
+      %(<#{element}>#{node.text}</#{element}>)
     when :superscript
       %(<sup>#{node.text}</sup>)
     when :subscript

--- a/lib/dita-topic.rb
+++ b/lib/dita-topic.rb
@@ -455,9 +455,10 @@ class DitaTopic < Asciidoctor::Converter::Base
         # Define supported roles:
         semantic_markup = {
           'command'   => 'cmdname',
-          'filename'  => 'filepath',
           'directory' => 'filepath',
-          'option'    => 'option'
+          'filename'  => 'filepath',
+          'option'    => 'option',
+          'variable'  => 'varname'
         }
 
         # Select the appropriate semantic element:

--- a/lib/dita-topic.rb
+++ b/lib/dita-topic.rb
@@ -38,9 +38,6 @@ class DitaTopic < Asciidoctor::Converter::Base
     # Disable the author line by default:
     @authors_allowed = false
 
-    # Disable semantic markup by default:
-    @semantic_allowed = false
-
     # Enable abstract paragraphs by default:
     @abstracts_allowed = true
 
@@ -57,9 +54,6 @@ class DitaTopic < Asciidoctor::Converter::Base
   def convert_document node
     # Check if the author line is enabled:
     @authors_allowed = true if (node.attr 'dita-topic-authors') == 'on'
-
-    # Check if semantic markup is enabled:
-    @semantic_allowed = true if (node.attr 'dita-topic-semantic') == 'on'
 
     # Check if abstract paragraphs are enabled:
     @abstracts_allowed = false if (node.attr 'dita-topic-abstracts') == 'off'
@@ -456,8 +450,8 @@ class DitaTopic < Asciidoctor::Converter::Base
     when :strong
       %(<b>#{node.text}</b>)
     when :monospaced
-      # Check whether semantic markup is enabled:
-      if @semantic_allowed and node.role
+      # Check whether a role is provided:
+      if node.role
         # Define supported roles:
         semantic_markup = {
           'command'   => 'cmdname',

--- a/test/test_inline_quoted.rb
+++ b/test/test_inline_quoted.rb
@@ -54,4 +54,21 @@ class InlineQuotedTest < Minitest::Test
     assert_xpath_equal xml, 'latexmath end', '//p/comment()[2]'
     assert_xpath_equal xml, '\alpha = \beta + \gamma', '//p/text()[2]'
   end
+
+  def test_semantic_markup
+    xml = <<~EOF.chomp.to_dita
+    :dita-topic-semantic: on
+
+    * [command]`a command`
+    * [filename]`a file name`
+    * [directory]`a directory name`
+    * [option]`an option`
+    EOF
+
+    assert_xpath_count xml, 4, '//li'
+    assert_xpath_equal xml, 'a command', '//li[1]/cmdname/text()'
+    assert_xpath_equal xml, 'a file name', '//li[2]/filepath/text()'
+    assert_xpath_equal xml, 'a directory name', '//li[3]/filepath/text()'
+    assert_xpath_equal xml, 'an option', '//li[4]/option/text()'
+  end
 end

--- a/test/test_inline_quoted.rb
+++ b/test/test_inline_quoted.rb
@@ -57,8 +57,6 @@ class InlineQuotedTest < Minitest::Test
 
   def test_semantic_markup
     xml = <<~EOF.chomp.to_dita
-    :dita-topic-semantic: on
-
     * [command]`a command`
     * [filename]`a file name`
     * [directory]`a directory name`

--- a/test/test_inline_quoted.rb
+++ b/test/test_inline_quoted.rb
@@ -58,15 +58,17 @@ class InlineQuotedTest < Minitest::Test
   def test_semantic_markup
     xml = <<~EOF.chomp.to_dita
     * [command]`a command`
-    * [filename]`a file name`
     * [directory]`a directory name`
+    * [filename]`a file name`
     * [option]`an option`
+    * [variable]`a variable`
     EOF
 
-    assert_xpath_count xml, 4, '//li'
+    assert_xpath_count xml, 5, '//li'
     assert_xpath_equal xml, 'a command', '//li[1]/cmdname/text()'
-    assert_xpath_equal xml, 'a file name', '//li[2]/filepath/text()'
-    assert_xpath_equal xml, 'a directory name', '//li[3]/filepath/text()'
+    assert_xpath_equal xml, 'a directory name', '//li[2]/filepath/text()'
+    assert_xpath_equal xml, 'a file name', '//li[3]/filepath/text()'
     assert_xpath_equal xml, 'an option', '//li[4]/option/text()'
+    assert_xpath_equal xml, 'a variable', '//li[5]/varname/text()'
   end
 end


### PR DESCRIPTION
This implementation is intentionally minimal and focuses on elements that benefit from having semantic meaning the most. I stayed clear from going down the rabbit hole as I don't want to introduce markup that would increase the chance of producing invalid DITA topics. The following is a complete list of AsciiDoc roles that are recognized [when assigned as a role](https://docs.asciidoctor.org/asciidoc/latest/attributes/role/#assign-roles-to-formatted-inline-elements) to inline monospace text:

| AsciiDoc Role | DITA Element |
| --- | --- |
| command |`<cmdname>` |
| directory | `<filepath>` |
| filename | `<filepath>` |
| option | `<option>` |
| variable | `<varname>` |

Example usage:

```console
$ echo '[filename]`/etc/passwd`' | asciidoctor -r dita-topic -b dita-topic - | xmllint --xpath '//p' -
<p><filepath>/etc/passwd</filepath></p>
```

### Implementation checklist

- [x] The new code comes with the corresponding test cases
- [x] The new code comes with the corresponding documentation in the `README.adoc` file
- [x] The new code passes all tests (run `rake test` in the project directory)