### PR TITLE
Add support for the audio and video macros

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -248,8 +248,6 @@ Table footers not supported in DITA:: AsciiDoc allows you to set the `footer` op
 
 Thematic breaks not supported in DITA:: Asciidoc allows you to use `'''`, `---`, or `\***` (the last two with possible optional spaces in between the characters) to insert a thematic break in between two blocks, most commonly represented by a horizontal line. Unlike AsciiDoc, DITA does not support thematic breaks. `dita-topic` issues this warning whenever a thematic break is present in the converted AsciiDoc file.
 
-Video macro not supported:: AsciiDoc allows you to embed video content in your documents by using the `video::__video_file__[]` macro. `dita-topic` does not implement this feature and issues this warning whenever the `video` macro is present in the converted AsciiDoc file.
-
 [#copyright]
 == Copyright
 

--- a/README.adoc
+++ b/README.adoc
@@ -222,8 +222,6 @@ This possible warning messages are as follows:
 [horizontal]
 Admonition titles not supported in DITA:: AsciiDoc allows you to add a custom title to any admonition by including `._Admonition title_` on the line above it. Unlike AsciiDoc, DITA does not allow titles for admonitions. `dita-topic` issues this warning whenever an admonition has a title defined in the converted AsciiDoc file.
 
-Audio macro not supported:: AsciiDoc allows you to embed audio content in your documents by using the `audio::__audio_file__[]` macro. `dita-topic` does not implement this feature and issues this warning whenever the `audio` macro is present in the converted AsciiDoc file.
-
 Author lines not enabled for topics:: AsciiDoc interprets the first line that directly follows the document title as an author line. Because topics are not expected to have author lines, `dita-topic` issues this warning when an author line is present in the converted AsciiDoc file.
 
 Block titles not supported in DITA:: AsciiDoc allows you to include `._Block title_` on the line above most of the block elements to assign a custom title to them. Unlike AsciiDoc, DITA only allows titles to be assigned to a limited number of elements. `dita-topic` issues this warning when the `-a dita-topic-titles=off` option is specified and a block title is present in the converted AsciiDoc file.

--- a/lib/dita-topic.rb
+++ b/lib/dita-topic.rb
@@ -129,9 +129,16 @@ class DitaTopic < Asciidoctor::Converter::Base
   end
 
   def convert_audio node
-    # Issue a warning if audio content is present:
-    logger.warn "#{NAME}: Audio macro not supported"
-    return ''
+    # Check if the audio macro has a title specified:
+    if node.title?
+      <<~EOF.chomp
+      <object data="#{node.media_uri(node.attr 'target')}">
+        <desc>#{node.title}</desc>
+      </object>
+      EOF
+    else
+      %(<object data="#{node.media_uri(node.attr 'target')}" />)
+    end
   end
 
   def convert_colist node

--- a/lib/dita-topic.rb
+++ b/lib/dita-topic.rb
@@ -802,9 +802,20 @@ class DitaTopic < Asciidoctor::Converter::Base
   end
 
   def convert_video node
-    # Issue a warning if video content is present:
-    logger.warn "#{NAME}: Video macro not supported"
-    return ''
+    # Check if additional attributes are specified:
+    width  = (node.attr? 'width') ? %( width="#{node.attr 'width'}") : ''
+    height = (node.attr? 'height') ? %( height="#{node.attr 'height'}") : ''
+
+    # Check if the audio macro has a title specified:
+    if node.title?
+      <<~EOF.chomp
+      <object data="#{node.media_uri(node.attr 'target')}"#{width}#{height}>
+        <desc>#{node.title}</desc>
+      </object>
+      EOF
+    else
+      %(<object data="#{node.media_uri(node.attr 'target')}"#{width}#{height} />)
+    end
   end
 
   def compose_qanda_dlist node

--- a/lib/dita-topic.rb
+++ b/lib/dita-topic.rb
@@ -807,7 +807,7 @@ class DitaTopic < Asciidoctor::Converter::Base
     height = (node.attr? 'height') ? %( height="#{node.attr 'height'}") : ''
 
     # Check if the video is a Vimeo or YouTube video:
-    if (node.attr 'poster') == 'youtube'
+    if (provider = (node.attr 'poster')) == 'youtube'
       # Separate a playlist from the target:
       target, list = (node.attr 'target').split '/', 2
 
@@ -821,6 +821,8 @@ class DitaTopic < Asciidoctor::Converter::Base
 
       # Compose the target URL:
       target_url = %(https://www.youtube.com/embed/#{target}#{list})
+    elsif provider == 'vimeo'
+      target_url = %(https://player.vimeo.com/video/#{node.attr 'target'})
     else
       target_url = node.media_uri(node.attr 'target')
     end

--- a/lib/dita-topic.rb
+++ b/lib/dita-topic.rb
@@ -806,15 +806,34 @@ class DitaTopic < Asciidoctor::Converter::Base
     width  = (node.attr? 'width') ? %( width="#{node.attr 'width'}") : ''
     height = (node.attr? 'height') ? %( height="#{node.attr 'height'}") : ''
 
+    # Check if the video is a Vimeo or YouTube video:
+    if (node.attr 'poster') == 'youtube'
+      # Separate a playlist from the target:
+      target, list = (node.attr 'target').split '/', 2
+
+      # Check if the playlist is provided as an attribute:
+      if node.attr 'list' and not list
+        list = node.attr 'list'
+      end
+
+      # Compose the playlist URL fragment:
+      list = list ? %(?list=#{list}) : ''
+
+      # Compose the target URL:
+      target_url = %(https://www.youtube.com/embed/#{target}#{list})
+    else
+      target_url = node.media_uri(node.attr 'target')
+    end
+
     # Check if the audio macro has a title specified:
     if node.title?
       <<~EOF.chomp
-      <object data="#{node.media_uri(node.attr 'target')}"#{width}#{height}>
+      <object data="#{target_url}"#{width}#{height}>
         <desc>#{node.title}</desc>
       </object>
       EOF
     else
-      %(<object data="#{node.media_uri(node.attr 'target')}"#{width}#{height} />)
+      %(<object data="#{target_url}"#{width}#{height} />)
     end
   end
 

--- a/test/test_audio.rb
+++ b/test/test_audio.rb
@@ -1,0 +1,22 @@
+require 'minitest/autorun'
+require_relative 'helper'
+
+class AudioTest < Minitest::Test
+  def test_audio_definition
+    xml = <<~EOF.chomp.to_dita
+    audio::audio.wav[]
+    EOF
+
+    assert_xpath_equal xml, 'audio.wav', '//object/@data'
+  end
+
+  def test_audio_with_title
+    xml = <<~EOF.chomp.to_dita
+    .Audio title
+    audio::audio.wav[]
+    EOF
+
+    assert_xpath_equal xml, 'Audio title', '//object/desc/text()'
+    assert_xpath_equal xml, 'audio.wav', '//object/@data'
+  end
+end

--- a/test/test_video.rb
+++ b/test/test_video.rb
@@ -30,6 +30,14 @@ class VideoTest < Minitest::Test
     assert_xpath_equal xml, '480', '//object/@height'
   end
 
+  def test_vimeo_video
+    xml = <<~EOF.chomp.to_dita
+    video::67480300[vimeo]
+    EOF
+
+    assert_xpath_equal xml, 'https://player.vimeo.com/video/67480300', '//object/@data'
+  end
+
   def test_youtube_video
     xml = <<~EOF.chomp.to_dita
     video::lJIrF4YjHfQ[youtube]

--- a/test/test_video.rb
+++ b/test/test_video.rb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 require_relative 'helper'
 
 class VideoTest < Minitest::Test
-  def test_audio_definition
+  def test_video_definition
     xml = <<~EOF.chomp.to_dita
     video::video.mp4[]
     EOF
@@ -10,13 +10,47 @@ class VideoTest < Minitest::Test
     assert_xpath_equal xml, 'video.mp4', '//object/@data'
   end
 
-  def test_audio_with_title
+  def test_video_with_title
     xml = <<~EOF.chomp.to_dita
     .Video title
-    audio::video.mp4[]
+    video::video.mp4[]
     EOF
 
     assert_xpath_equal xml, 'Video title', '//object/desc/text()'
     assert_xpath_equal xml, 'video.mp4', '//object/@data'
+  end
+
+  def test_video_sizing
+    xml = <<~EOF.chomp.to_dita
+    video::video.mp4[width=640,height=480]
+    EOF
+
+    assert_xpath_equal xml, 'video.mp4', '//object/@data'
+    assert_xpath_equal xml, '640', '//object/@width'
+    assert_xpath_equal xml, '480', '//object/@height'
+  end
+
+  def test_youtube_video
+    xml = <<~EOF.chomp.to_dita
+    video::lJIrF4YjHfQ[youtube]
+    EOF
+
+    assert_xpath_equal xml, 'https://www.youtube.com/embed/lJIrF4YjHfQ', '//object/@data'
+  end
+
+  def test_youtube_with_playlist_target
+    xml = <<~EOF.chomp.to_dita
+    video::lJIrF4YjHfQ/PL9hW1uS6HUftRY4bk3ScHu4WvvMU0wMkD[youtube]
+    EOF
+
+    assert_xpath_equal xml, 'https://www.youtube.com/embed/lJIrF4YjHfQ?list=PL9hW1uS6HUftRY4bk3ScHu4WvvMU0wMkD', '//object/@data'
+  end
+
+  def test_youtube_with_playlist_attribute
+    xml = <<~EOF.chomp.to_dita
+    video::lJIrF4YjHfQ[youtube,list=PL9hW1uS6HUftRY4bk3ScHu4WvvMU0wMkD]
+    EOF
+
+    assert_xpath_equal xml, 'https://www.youtube.com/embed/lJIrF4YjHfQ?list=PL9hW1uS6HUftRY4bk3ScHu4WvvMU0wMkD', '//object/@data'
   end
 end

--- a/test/test_video.rb
+++ b/test/test_video.rb
@@ -1,0 +1,22 @@
+require 'minitest/autorun'
+require_relative 'helper'
+
+class VideoTest < Minitest::Test
+  def test_audio_definition
+    xml = <<~EOF.chomp.to_dita
+    video::video.mp4[]
+    EOF
+
+    assert_xpath_equal xml, 'video.mp4', '//object/@data'
+  end
+
+  def test_audio_with_title
+    xml = <<~EOF.chomp.to_dita
+    .Video title
+    audio::video.mp4[]
+    EOF
+
+    assert_xpath_equal xml, 'Video title', '//object/desc/text()'
+    assert_xpath_equal xml, 'video.mp4', '//object/@data'
+  end
+end


### PR DESCRIPTION
Initial implementation of basic support for [audio and video macros](https://docs.asciidoctor.org/asciidoc/latest/macros/audio-and-video/).

### Implementation checklist

- [x] The new code comes with the corresponding test cases
- [x] The new code comes with the corresponding documentation in the `README.adoc` file
- [x] The new code passes all tests (run `rake test` in the project directory)