### PR TITLE
Disable callouts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -120,6 +120,18 @@ To enable processing of author lines as metadata, set the value of the `dita-top
 $ **asciidoctor -r dita-topic -b dita-topic -a dita-topic-authors=on _your_file_.adoc**
 ....
 
+[#callouts]
+=== Enabling callouts
+
+Unlike AsciiDoc, DITA does not support callouts as a method to add annotations to specific lines in verbatim blocks. For this reason, the conversion of callouts is disabled by default.
+
+If callouts are required, the `dita-topic` converter can use XML entities for circled numbers in place of callouts. To enable this behavior, set the value of the `dita-topic-callouts` to `on`:
+
+[literal,subs="+quotes"]
+....
+$ **asciidoctor -r dita-topic -b dita-topic -a dita-topic-callouts=on _your_file_.adoc**
+....
+
 [#titles]
 === Disabling floating titles
 
@@ -135,18 +147,6 @@ To disable this behavior, set the value of the `dita-topic-titles` to `off`:
 [literal,subs="+quotes"]
 ....
 $ **asciidoctor -r dita-topic -b dita-topic -a dita-topic-titles=off _your_file_.adoc**
-....
-
-[#callouts]
-=== Disabling callouts
-
-Unlike AsciiDoc, DITA does not support callouts as a method to add annotations to specific lines in verbatim blocks. To avoid losing content during conversion, as a workaround, the `dita-topic` converter uses XML entities for circled numbers.
-
-To disable this behavior, set the value of the `dita-topic-callouts` to `off`:
-
-[literal,subs="+quotes"]
-....
-$ **asciidoctor -r dita-topic -b dita-topic -a dita-topic-callouts=off _your_file_.adoc**
 ....
 
 [#includes]

--- a/lib/dita-topic.rb
+++ b/lib/dita-topic.rb
@@ -39,7 +39,7 @@ class DitaTopic < Asciidoctor::Converter::Base
     @authors_allowed = false
 
     # Enable callouts by default:
-    @callouts_allowed = true
+    @callouts_allowed = false
 
     # Enable floating and block titles by default:
     @titles_allowed = true
@@ -53,7 +53,7 @@ class DitaTopic < Asciidoctor::Converter::Base
     @authors_allowed = true if (node.attr 'dita-topic-authors') == 'on'
 
     # Check if callouts are enabled:
-    @callouts_allowed = false if (node.attr 'dita-topic-callouts') == 'off'
+    @callouts_allowed = true if (node.attr 'dita-topic-callouts') == 'on'
 
     # Check if floating and block titles are enabled:
     @titles_allowed = false if (node.attr 'dita-topic-titles') == 'off'

--- a/test/test_colist.rb
+++ b/test/test_colist.rb
@@ -4,6 +4,8 @@ require_relative 'helper'
 class ColistTest < Minitest::Test
   def test_simple_colist
     xml = <<~EOF.chomp.to_dita
+    :dita-topic-callouts: on
+
     [source,ruby]
     ----
     require 'asciidoctor'
@@ -30,6 +32,8 @@ class ColistTest < Minitest::Test
 
   def test_colist_outputclass
     xml = <<~EOF.chomp.to_dita
+    :dita-topic-callouts: on
+
     ----
     Code line <1>
     ----

--- a/test/test_inline_callout.rb
+++ b/test/test_inline_callout.rb
@@ -4,6 +4,8 @@ require_relative 'helper'
 class InlineCalloutTest < Minitest::Test
   def test_callout_number_outputclass
     xml = <<~EOF.chomp.to_dita
+    :dita-topic-callouts: on
+
     ....
     puts "Testing a callout" <1>
     ....
@@ -14,6 +16,8 @@ class InlineCalloutTest < Minitest::Test
 
   def test_callout_number_range
     xml = <<~EOF.chomp.to_dita
+    :dita-topic-callouts: on
+
     ....
     1: <1>
     ....


### PR DESCRIPTION
Callout lists do not have a direct equivalent in DITA. While the conversion tooling can work around this limitation by injecting circled numbers in code blocks and placing the explanations in a definition list, it is not a clean solution. Because of this, the conversion of callouts is now disabled by default.