### PR TITLE
Add support for metadata attributes

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['3.4', '3.2', '3.0', '2.7']
+        ruby-version: ['3.4', '3.2', '3.0']
 
     steps:
     - uses: actions/checkout@v4

--- a/lib/dita-topic.rb
+++ b/lib/dita-topic.rb
@@ -1023,6 +1023,43 @@ class DitaTopic < Asciidoctor::Converter::Base
     return outputclass
   end
 
+  def compose_metadata node
+    # Check if the role is defined:
+    return '' unless node.role
+
+    # Set the initial value:
+    result = {}
+
+    # Define supported metadata attributes:
+    valid  = ['platform', 'product', 'audience', 'otherprops']
+
+    # Process each role:
+    node.role.split.each do |role|
+      # Ignore roles that do not follow the attribute:value format:
+      next unless role.include? ':'
+
+      # Separate the attribute name from its value:
+      attribute, value = role.split ':'
+
+      # Ignore unsupported attribute names:
+      next unless valid.include? attribute
+
+      # Append the value to the attribute:
+      if result.key? attribute
+        result[attribute] << %( #{value})
+      else
+        result[attribute] = %(#{value})
+      end
+    end
+
+    # Return the list of metadata attributes otherwise:
+    if result.empty?
+      return ''
+    else
+      return ' ' + result.map { |k, v| %(#{k}="#{v}") unless v.empty? }.join(' ')
+    end
+  end
+
   def format_message message
     # Compose the warning or error message:
     file_name = (defined? @file_name) ? %( #{@file_name}:) : ''

--- a/lib/dita-topic.rb
+++ b/lib/dita-topic.rb
@@ -453,10 +453,13 @@ class DitaTopic < Asciidoctor::Converter::Base
     # Determine the inline markup type:
     case node.type
     when :emphasis
-      %(<i>#{node.text}</i>)
+      %(<i#{compose_metadata node}>#{node.text}</i>)
     when :strong
-      %(<b>#{node.text}</b>)
+      %(<b#{compose_metadata node}>#{node.text}</b>)
     when :monospaced
+      # Set the default element value:
+      element = 'tt'
+
       # Check if the role is provided:
       if node.role
         # Define supported roles:
@@ -468,19 +471,19 @@ class DitaTopic < Asciidoctor::Converter::Base
           'variable'  => 'varname'
         }
 
-        # Select the appropriate semantic element:
-        element = (semantic_markup.key? node.role) ? semantic_markup[node.role] : 'tt'
-      else
-        # Use the teletype element by default:
-        element = 'tt'
+        # Process each role:
+        node.role.split.each do |role|
+          # Select the appropriate semantic element:
+          element = semantic_markup[role] if semantic_markup.key? role
+        end
       end
 
       # Return the result:
-      %(<#{element}>#{node.text}</#{element}>)
+      %(<#{element}#{compose_metadata node}>#{node.text}</#{element}>)
     when :superscript
-      %(<sup>#{node.text}</sup>)
+      %(<sup#{compose_metadata node}>#{node.text}</sup>)
     when :subscript
-      %(<sub>#{node.text}</sub>)
+      %(<sub#{compose_metadata node}>#{node.text}</sub>)
     when :double
       %(&#8220;#{node.text}&#8221;)
     when :single

--- a/lib/dita-topic.rb
+++ b/lib/dita-topic.rb
@@ -231,7 +231,7 @@ class DitaTopic < Asciidoctor::Converter::Base
     result << %(</dl>)
 
     # Return the XML output:
-    add_block_title (result.join LF), node.title
+    add_block_title (result.join LF), node
   end
 
   def convert_example node
@@ -514,7 +514,7 @@ class DitaTopic < Asciidoctor::Converter::Base
     EOF
 
     # Return the XML output:
-    add_block_title result, node.title
+    add_block_title result, node
   end
 
   def convert_literal node
@@ -526,7 +526,7 @@ class DitaTopic < Asciidoctor::Converter::Base
     EOF
 
     # Return the XML output:
-    add_block_title result, node.title
+    add_block_title result, node
   end
 
   def convert_olist node
@@ -549,7 +549,7 @@ class DitaTopic < Asciidoctor::Converter::Base
     result << '</ol>'
 
     # Return the XML output:
-    add_block_title (result.join LF), node.title
+    add_block_title (result.join LF), node
   end
 
   def convert_open node
@@ -584,9 +584,9 @@ class DitaTopic < Asciidoctor::Converter::Base
 
   def convert_paragraph node
     if (node.attr 'role') and (node.attr 'role').split.include? '_abstract'
-      add_block_title %(<p outputclass="abstract"#{compose_metadata node}>#{node.content}</p>), node.title
+      add_block_title %(<p outputclass="abstract"#{compose_metadata node}>#{node.content}</p>), node
     else
-      add_block_title %(<p#{compose_metadata node}>#{node.content}</p>), node.title
+      add_block_title %(<p#{compose_metadata node}>#{node.content}</p>), node
     end
   end
 
@@ -792,7 +792,7 @@ class DitaTopic < Asciidoctor::Converter::Base
     result << '</ul>'
 
     # Returned the XML output:
-    add_block_title (result.join LF), node.title
+    add_block_title (result.join LF), node
   end
 
   def convert_verse node
@@ -876,7 +876,7 @@ class DitaTopic < Asciidoctor::Converter::Base
     result << %(</ol>)
 
     # Return the XML output:
-    add_block_title (result.join LF), node.title
+    add_block_title (result.join LF), node
   end
 
   def compose_horizontal_dlist node
@@ -943,13 +943,13 @@ class DitaTopic < Asciidoctor::Converter::Base
 
   # Helper methods
 
-  def add_block_title content, title
+  def add_block_title content, node
     # NOTE: Unlike AsciiDoc, DITA does not support titles assigned to
     # certain block elements. As a workaround, I decided to use a paragraph
     # with the outputclass attribute.
 
     # Check if the title is defined:
-    return content unless title
+    return content unless node.title
 
     # Issue a warning if block titles are disabled:
     unless @titles_allowed
@@ -959,7 +959,7 @@ class DitaTopic < Asciidoctor::Converter::Base
 
     # Return the XML output:
     <<~EOF.chomp
-    <p outputclass="title"><b>#{title}</b></p>
+    <p outputclass="title"#{compose_metadata node}><b>#{node.title}</b></p>
     #{content}
     EOF
   end

--- a/test/test_admonition.rb
+++ b/test/test_admonition.rb
@@ -62,4 +62,43 @@ class AdmonitionTest < Minitest::Test
 
     assert_xpath_count xml, 2, '//note[@type="tip"]/p'
   end
+
+  def test_supported_roles
+    xml = <<~EOF.chomp.to_dita
+    [role="platform:linux product:asciidoctor audience:novice otherprops:pdf"]
+    TIP: This is a tip.
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//note/@platform'
+    assert_xpath_equal xml, 'asciidoctor', '//note/@product'
+    assert_xpath_equal xml, 'novice', '//note/@audience'
+    assert_xpath_equal xml, 'pdf', '//note/@otherprops'
+  end
+
+  def test_multiple_roles
+    xml = <<~EOF.chomp.to_dita
+    [role="platform:linux platform:mac"]
+    TIP: This is a tip.
+    EOF
+
+    assert_xpath_equal xml, 'linux mac', '//note/@platform'
+  end
+
+  def test_no_roles
+    xml = <<~EOF.chomp.to_dita
+    [role=""]
+    TIP: This is a tip.
+    EOF
+
+    assert_xpath_count xml, 0, '//note/@platform'
+  end
+
+  def test_invalid_roles
+    xml = <<~EOF.chomp.to_dita
+    [role="invalid:value"]
+    TIP: This is a tip.
+    EOF
+
+    assert_xpath_count xml, 0, '//note/@platform'
+  end
 end

--- a/test/test_audio.rb
+++ b/test/test_audio.rb
@@ -19,4 +19,23 @@ class AudioTest < Minitest::Test
     assert_xpath_equal xml, 'Audio title', '//object/desc/text()'
     assert_xpath_equal xml, 'audio.wav', '//object/@data'
   end
+
+  def test_audio_role
+    xml = <<~EOF.chomp.to_dita
+    [role="platform:linux"]
+    audio::audio.wav[]
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//object/@platform'
+  end
+
+  def test_audio_role_with_title
+    xml = <<~EOF.chomp.to_dita
+    [role="platform:linux"]
+    .Audio title
+    audio::audio.wav[]
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//object/@platform'
+  end
 end

--- a/test/test_colist.rb
+++ b/test/test_colist.rb
@@ -42,4 +42,18 @@ class ColistTest < Minitest::Test
 
     assert_xpath_equal xml, 'callout-list', '//dl/@outputclass'
   end
+
+  def test_colist_role
+    xml = <<~EOF.chomp.to_dita
+    :dita-topic-callouts: on
+
+    ----
+    Code line <1>
+    ----
+    [role="platform:linux"]
+    <1> Code description
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//dl/@platform'
+  end
 end

--- a/test/test_dlist.rb
+++ b/test/test_dlist.rb
@@ -60,4 +60,14 @@ class DlistTest < Minitest::Test
     assert_xpath_equal xml, 'A description list title', '//p[@outputclass="title"]/b/text()'
     assert_xpath_count xml, 2, '//dl/dlentry'
   end
+
+  def test_description_list_role
+    xml = <<~EOF.chomp.to_dita
+    [role="platform:linux"]
+    Term1:: Definition one
+    Term2:: Definition two
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//dl/@platform'
+  end
 end

--- a/test/test_dlist.rb
+++ b/test/test_dlist.rb
@@ -64,10 +64,12 @@ class DlistTest < Minitest::Test
   def test_description_list_role
     xml = <<~EOF.chomp.to_dita
     [role="platform:linux"]
+    .A description list title
     Term1:: Definition one
     Term2:: Definition two
     EOF
 
     assert_xpath_equal xml, 'linux', '//dl/@platform'
+    assert_xpath_equal xml, 'linux', '//p[@outputclass="title"]/@platform'
   end
 end

--- a/test/test_example.rb
+++ b/test/test_example.rb
@@ -43,4 +43,15 @@ class ExampleTest < Minitest::Test
     assert_xpath_equal xml, 'An example block title', '//example/title/text()'
     assert_xpath_equal xml, 'An example block', '//example/p/text()'
   end
+
+  def test_example_role
+    xml = <<~EOF.chomp.to_dita
+    [role="platform:linux"]
+    ====
+    An example block
+    ====
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//example/@platform'
+  end
 end

--- a/test/test_floating_title.rb
+++ b/test/test_floating_title.rb
@@ -30,4 +30,13 @@ class FloatingTitleTest < Minitest::Test
     assert_xpath_includes xml, 'Section 4', '//p[@outputclass="title sect4"]/b/text()'
     assert_xpath_includes xml, 'Section 5', '//p[@outputclass="title sect5"]/b/text()'
   end
+
+  def test_section_role
+    xml = <<~EOF.chomp.to_dita
+    [discrete,role="platform:linux"]
+    == Section 1
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//p[@outputclass="title sect1"]/@platform'
+  end
 end

--- a/test/test_horizontal_dlist.rb
+++ b/test/test_horizontal_dlist.rb
@@ -48,4 +48,14 @@ class HorizontalDlistTest < Minitest::Test
     assert_xpath_equal xml, 'A description list title', '//table/title/text()'
     assert_xpath_count xml, 2, '//table/tgroup/tbody/row'
   end
+
+  def test_horizontal_dlist_role
+    xml = <<~EOF.chomp.to_dita
+    [horizontal,role="platform:linux"]
+    Term1:: Definition one
+    Term2:: Definition two
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//table/@platform'
+  end
 end

--- a/test/test_image.rb
+++ b/test/test_image.rb
@@ -68,4 +68,23 @@ class ImageTest < Minitest::Test
     assert_xpath_equal xml, 'Image title', '//fig/title/text()'
     assert_xpath_equal xml, 'image.png', '//fig/image/@href'
   end
+
+  def test_image_role
+    xml = <<~EOF.chomp.to_dita
+    [role="platform:linux"]
+    image::image.png[]
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//image/@platform'
+  end
+
+  def test_image_role_with_title
+    xml = <<~EOF.chomp.to_dita
+    [role="platform:linux"]
+    .Image title
+    image::image.png[]
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//fig/@platform'
+  end
 end

--- a/test/test_inline_quoted.rb
+++ b/test/test_inline_quoted.rb
@@ -71,4 +71,33 @@ class InlineQuotedTest < Minitest::Test
     assert_xpath_equal xml, 'an option', '//li[4]/option/text()'
     assert_xpath_equal xml, 'a variable', '//li[5]/varname/text()'
   end
+
+  def test_markup_roles
+    xml = <<~EOF.chomp.to_dita
+    Inline markup for [.platform:linux]_emphasis_, [.platform:linux]*strong*, [.platform:linux]`monospace`,
+    [.platform:linux]^superscript^, and [.platform:linux]~subscript~.
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//i/@platform'
+    assert_xpath_equal xml, 'linux', '//b/@platform'
+    assert_xpath_equal xml, 'linux', '//tt/@platform'
+    assert_xpath_equal xml, 'linux', '//sup/@platform'
+    assert_xpath_equal xml, 'linux', '//sub/@platform'
+  end
+
+  def test_semantic_markup_roles
+    xml = <<~EOF.chomp.to_dita
+    * [.command.platform:linux]`a command`
+    * [.directory.platform:linux]`a directory name`
+    * [.filename.platform:linux]`a file name`
+    * [.option.platform:linux]`an option`
+    * [.variable.platform:linux]`a variable`
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//li[1]/cmdname/@platform'
+    assert_xpath_equal xml, 'linux', '//li[2]/filepath/@platform'
+    assert_xpath_equal xml, 'linux', '//li[3]/filepath/@platform'
+    assert_xpath_equal xml, 'linux', '//li[4]/option/@platform'
+    assert_xpath_equal xml, 'linux', '//li[5]/varname/@platform'
+  end
 end

--- a/test/test_listing.rb
+++ b/test/test_listing.rb
@@ -80,9 +80,11 @@ class ListingTest < Minitest::Test
   def test_source_block_role
     xml = <<~EOF.chomp.to_dita
     [source,role="platform:linux"]
+    .A listing block title
     A source code block
     EOF
 
     assert_xpath_equal xml, 'linux', '//codeblock/@platform'
+    assert_xpath_equal xml, 'linux', '//p[@outputclass="title"]/@platform'
   end
 end

--- a/test/test_listing.rb
+++ b/test/test_listing.rb
@@ -76,4 +76,13 @@ class ListingTest < Minitest::Test
 
     assert_xpath_equal xml, 'language-ruby', '//codeblock/@outputclass'
   end
+
+  def test_source_block_role
+    xml = <<~EOF.chomp.to_dita
+    [source,role="platform:linux"]
+    A source code block
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//codeblock/@platform'
+  end
 end

--- a/test/test_literal.rb
+++ b/test/test_literal.rb
@@ -41,4 +41,13 @@ class LiteralTest < Minitest::Test
     assert_xpath_equal xml, 'A literal block title', '//p[@outputclass="title"]/b/text()'
     assert_xpath_equal xml, 'A literal block', '//pre/text()'
   end
+
+  def test_literal_block_role
+    xml = <<~EOF.chomp.to_dita
+    [literal,role="platform:linux"]
+    A literal block
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//pre/@platform'
+  end
 end

--- a/test/test_literal.rb
+++ b/test/test_literal.rb
@@ -45,9 +45,11 @@ class LiteralTest < Minitest::Test
   def test_literal_block_role
     xml = <<~EOF.chomp.to_dita
     [literal,role="platform:linux"]
+    .A literal block title
     A literal block
     EOF
 
     assert_xpath_equal xml, 'linux', '//pre/@platform'
+    assert_xpath_equal xml, 'linux', '//p[@outputclass="title"]/@platform'
   end
 end

--- a/test/test_olist.rb
+++ b/test/test_olist.rb
@@ -38,10 +38,12 @@ class OlistTest < Minitest::Test
   def test_ordered_list_role
     xml = <<~EOF.chomp.to_dita
     [role="platform:linux"]
+    .An ordered list title
     . Item one
     . Item two
     EOF
 
     assert_xpath_equal xml, 'linux', '//ol/@platform'
+    assert_xpath_equal xml, 'linux', '//p[@outputclass="title"]/@platform'
   end
 end

--- a/test/test_olist.rb
+++ b/test/test_olist.rb
@@ -34,4 +34,14 @@ class OlistTest < Minitest::Test
     assert_xpath_equal xml, 'An ordered list title', '//p[@outputclass="title"]/b/text()'
     assert_xpath_count xml, 2, '//ol/li'
   end
+
+  def test_ordered_list_role
+    xml = <<~EOF.chomp.to_dita
+    [role="platform:linux"]
+    . Item one
+    . Item two
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//ol/@platform'
+  end
 end

--- a/test/test_open.rb
+++ b/test/test_open.rb
@@ -75,4 +75,45 @@ class OpenTest < Minitest::Test
     assert_xpath_count xml, 1, '//body/p'
     assert_xpath_count xml, 1, '//body/section/p'
   end
+
+  def test_simple_abstract_role
+    xml = <<~EOF.chomp.to_dita
+    = A document header
+
+    [abstract,role="platform:linux"]
+    An abstract.
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//body/p/@platform'
+  end
+
+  def test_compound_abstract_role
+    xml = <<~EOF.chomp.to_dita
+    = A document header
+
+    [abstract,role="platform:linux"]
+    --
+    An abstract.
+
+    An abstract continued.
+    --
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//body/div/@platform'
+  end
+
+  def test_part_introduction_role
+    xml = <<~EOF.chomp.to_dita 'book'
+    = A document header
+
+    A paragraph.
+
+    = A part header
+
+    [role="platform:linux"]
+    A part introduction.
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//body/section/p/@platform'
+  end
 end

--- a/test/test_paragraph.rb
+++ b/test/test_paragraph.rb
@@ -27,4 +27,28 @@ class ParagraphTest < Minitest::Test
     assert_xpath_equal xml, 'abstract', '//body/p[1]/@outputclass'
     assert_xpath_count xml, 2, '//body/p'
   end
+
+  def test_paragraph_role
+    xml = <<~EOF.chomp.to_dita
+    [role="platform:linux"]
+    First paragraph.
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//p/@platform'
+  end
+
+  def test_abstract_paragraph_role
+    xml = <<~EOF.chomp.to_dita
+    [role="_abstract platform:linux"]
+    An abstract.
+
+    A paragraph.
+    EOF
+
+    assert_xpath_equal xml, 'An abstract.', '//body/p[1]/text()'
+    assert_xpath_equal xml, 'A paragraph.', '//body/p[2]/text()'
+    assert_xpath_equal xml, 'abstract', '//body/p[1]/@outputclass'
+    assert_xpath_equal xml, 'linux', '//body/p[1]/@platform'
+    assert_xpath_count xml, 2, '//body/p'
+  end
 end

--- a/test/test_paragraph.rb
+++ b/test/test_paragraph.rb
@@ -28,27 +28,50 @@ class ParagraphTest < Minitest::Test
     assert_xpath_count xml, 2, '//body/p'
   end
 
-  def test_paragraph_role
+  def test_paragraph_title
     xml = <<~EOF.chomp.to_dita
-    [role="platform:linux"]
-    First paragraph.
+    .A paragraph title
+    A paragraph.
     EOF
 
-    assert_xpath_equal xml, 'linux', '//p/@platform'
+    assert_xpath_equal xml, 'A paragraph title', '//p[@outputclass="title"]/b/text()'
+    assert_xpath_count xml, 2, '//body/p'
   end
 
-  def test_abstract_paragraph_role
+  def test_abstract_paragraph_title
     xml = <<~EOF.chomp.to_dita
-    [role="_abstract platform:linux"]
+    [role="_abstract"]
+    .An abstract paragraph title
     An abstract.
 
     A paragraph.
     EOF
 
-    assert_xpath_equal xml, 'An abstract.', '//body/p[1]/text()'
-    assert_xpath_equal xml, 'A paragraph.', '//body/p[2]/text()'
-    assert_xpath_equal xml, 'abstract', '//body/p[1]/@outputclass'
-    assert_xpath_equal xml, 'linux', '//body/p[1]/@platform'
-    assert_xpath_count xml, 2, '//body/p'
+    assert_xpath_equal xml, 'An abstract paragraph title', '//p[@outputclass="title"]/b/text()'
+    assert_xpath_count xml, 3, '//body/p'
+  end
+
+  def test_paragraph_role
+    xml = <<~EOF.chomp.to_dita
+    [role="platform:linux"]
+    .A paragraph title
+    First paragraph.
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//p[2]/@platform'
+    assert_xpath_equal xml, 'linux', '//p[1][@outputclass="title"]/@platform'
+  end
+
+  def test_abstract_paragraph_role
+    xml = <<~EOF.chomp.to_dita
+    [role="_abstract platform:linux"]
+    .An abstract paragraph title
+    An abstract.
+
+    A paragraph.
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//p[2]/@platform'
+    assert_xpath_equal xml, 'linux', '//p[1][@outputclass="title"]/@platform'
   end
 end

--- a/test/test_preamble.rb
+++ b/test/test_preamble.rb
@@ -19,4 +19,23 @@ class PreambleTest < Minitest::Test
     assert_xpath_equal xml, 'A preamble continued.', '//body/p[2]/text()'
     assert_xpath_count xml, 2, '//body/p'
   end
+
+  def test_preamble_role
+    xml = <<~EOF.chomp.to_dita
+    = A document header
+
+    [role="platform:linux"]
+    A preamble.
+
+    [role="platform:linux"]
+    A preamble continued.
+
+    == A section
+
+    A paragraph.
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//body/p[1]/@platform'
+    assert_xpath_equal xml, 'linux', '//body/p[2]/@platform'
+  end
 end

--- a/test/test_qanda_dlist.rb
+++ b/test/test_qanda_dlist.rb
@@ -43,4 +43,14 @@ class QuandaDlistTest < Minitest::Test
     assert_xpath_equal xml, 'A quanda list title', '//p[@outputclass="title"]/b/text()'
     assert_xpath_count xml, 2, '//ol/li'
   end
+
+  def test_qanda_list_role
+    xml = <<~EOF.chomp.to_dita
+    [qanda,role="platform:linux"]
+    Question 1:: Answer one
+    Question 2:: Answer two
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//ol/@platform'
+  end
 end

--- a/test/test_qanda_dlist.rb
+++ b/test/test_qanda_dlist.rb
@@ -47,10 +47,12 @@ class QuandaDlistTest < Minitest::Test
   def test_qanda_list_role
     xml = <<~EOF.chomp.to_dita
     [qanda,role="platform:linux"]
+    .A quanda list title
     Question 1:: Answer one
     Question 2:: Answer two
     EOF
 
     assert_xpath_equal xml, 'linux', '//ol/@platform'
+    assert_xpath_equal xml, 'linux', '//p[@outputclass="title"]/@platform'
   end
 end

--- a/test/test_quote.rb
+++ b/test/test_quote.rb
@@ -60,4 +60,26 @@ class QuoteTest < Minitest::Test
 
     assert_xpath_equal xml, 'Quote title', '//lq/p[@outputclass="title"]/b/text()'
   end
+
+  def test_quote_role
+    xml = <<~EOF.chomp.to_dita
+    [quote,Author Name,Quote source,role="platform:linux"]
+    Quoted line
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//lq/@platform'
+  end
+
+  def test_delimited_quote_role
+    xml = <<~EOF.chomp.to_dita
+    [quote,Author Name,Quote source,role="platform:linux"]
+    ____
+    First line
+
+    Second line
+    ____
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//lq/@platform'
+  end
 end

--- a/test/test_section.rb
+++ b/test/test_section.rb
@@ -85,4 +85,17 @@ class SectionTest < Minitest::Test
     assert_xpath_equal xml, 'procedure', '//section[2]/@outputclass'
     assert_xpath_equal xml, 'reference', '//section[3]/@outputclass'
   end
+
+  def test_section_role
+    xml = <<~EOF.chomp.to_dita
+    = Topic title
+
+    [role="platform:linux"]
+    == Section title
+
+    Section contents.
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//section/@platform'
+  end
 end

--- a/test/test_sidebar.rb
+++ b/test/test_sidebar.rb
@@ -47,4 +47,24 @@ class SidebarTest < Minitest::Test
     assert_xpath_equal xml, 'A sidebar title', '//div/p[@outputclass="title"]/b/text()'
     assert_xpath_equal xml, 'Sidebar text', '//div/p[2]/text()'
   end
+
+  def test_sidebar_role
+    xml = <<~EOF.chomp.to_dita
+    [sidebar,role="platform:linux"]
+    Sidebar text
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//div/@platform'
+  end
+
+  def test_delimited_sidebar_role
+    xml = <<~EOF.chomp.to_dita
+    [role="platform:linux"]
+    ****
+    Sidebar text
+    ****
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//div/@platform'
+  end
 end

--- a/test/test_table.rb
+++ b/test/test_table.rb
@@ -134,4 +134,18 @@ class TableTest < Minitest::Test
     assert_xpath_equal xml, 'Row 1, column 2', '//table/tgroup/tbody/row[1]/entry[2]/p/text()'
     assert_xpath_equal xml, 'Row 2, column 2', '//table/tgroup/tbody/row[2]/entry[1]/p/text()'
   end
+
+  def test_table_role
+    xml = <<~EOF.chomp.to_dita
+    [cols="1, 1",role="platform:linux"]
+    |===
+    |Column 1 header|Column 2 header
+
+    |Column 1
+    |Column 2
+    |===
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//table/@platform'
+  end
 end

--- a/test/test_ulist.rb
+++ b/test/test_ulist.rb
@@ -46,4 +46,14 @@ class UlistTest < Minitest::Test
     assert_xpath_equal xml, 'An unordered list title', '//p[@outputclass="title"]/b/text()'
     assert_xpath_count xml, 2, '//ul/li'
   end
+
+  def test_unordered_list_role
+    xml = <<~EOF.chomp.to_dita
+    [role="platform:linux"]
+    * Item one
+    * Item two
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//ul/@platform'
+  end
 end

--- a/test/test_ulist.rb
+++ b/test/test_ulist.rb
@@ -50,10 +50,12 @@ class UlistTest < Minitest::Test
   def test_unordered_list_role
     xml = <<~EOF.chomp.to_dita
     [role="platform:linux"]
+    .An unordered list title
     * Item one
     * Item two
     EOF
 
     assert_xpath_equal xml, 'linux', '//ul/@platform'
+    assert_xpath_equal xml, 'linux', '//p[@outputclass="title"]/@platform'
   end
 end

--- a/test/test_verse.rb
+++ b/test/test_verse.rb
@@ -43,4 +43,14 @@ class VerseTest < Minitest::Test
     assert_xpath_equal xml, 'Verse line', '//lines/text()'
     assert_xpath_equal xml, 'Citation source', '//lines/cite/text()'
   end
+
+  def test_verse_role
+    xml = <<~EOF.chomp.to_dita
+    [verse,role="platform:linux"]
+    First line
+    Second line
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//lines/@platform'
+  end
 end

--- a/test/test_video.rb
+++ b/test/test_video.rb
@@ -61,4 +61,23 @@ class VideoTest < Minitest::Test
 
     assert_xpath_equal xml, 'https://www.youtube.com/embed/lJIrF4YjHfQ?list=PL9hW1uS6HUftRY4bk3ScHu4WvvMU0wMkD', '//object/@data'
   end
+
+  def test_video_role
+    xml = <<~EOF.chomp.to_dita
+    [role="platform:linux"]
+    video::video.mp4[]
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//object/@platform'
+  end
+
+  def test_video_role_with_title
+    xml = <<~EOF.chomp.to_dita
+    [role="platform:linux"]
+    .Video title
+    video::video.mp4[]
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//object/@platform'
+  end
 end


### PR DESCRIPTION
DITA 1.3 supports [four metadata attributes for conditional processing](https://docs.oasis-open.org/dita/dita/v1.3/errata02/os/complete/part3-all-inclusive/langRef/attributes/metadataAttributes.html): `platform`, `product`, `audience`, and `otherprops`. This pull requests implements a mechanism which allows you to use [the role attribute](https://docs.asciidoctor.org/asciidoc/latest/attributes/role/) in AsciiDoc to propagate these four metadata attributes to the DITA output.

### Example AsciiDoc code

```asciidoc
[role="platform:linux platform:windows audience:novice"]
An example paragraph.

An example inline markup for [.platform:linux]_emphasis_, [.platform:linux]*strong*, [.platform:linux]`monospace`, [.platform:linux]^superscript^, and [.platform:linux]~subscript~.
```

### Example DITA output

```XML
<p platform="linux windows" audience="novice">An example paragraph.</p>
<p>An example inline markup for <i platform="linux">emphasis</i>, <b platform="linux">strong</b>, <tt platform="linux">monospace</tt>, <sup platform="linux">superscript</sup>, and <sub platform="linux">subscript</sub>.</p>
```