### PR TITLE
Added support for metadata attributes to inline images and links

### DIFF
--- a/lib/dita-topic.rb
+++ b/lib/dita-topic.rb
@@ -297,7 +297,7 @@ class DitaTopic < Asciidoctor::Converter::Base
     case node.type
     when :link
       # Compose an external link:
-      %(<xref href="#{node.target}" scope="external">#{node.text}</xref>)
+      %(<xref href="#{node.target}" scope="external"#{compose_metadata node}>#{node.text}</xref>)
     when :xref
       # NOTE: While AsciiDoc is happy to reference an ID that is not
       # defined in the same AsciiDoc file, DITA requires the topic ID as
@@ -312,7 +312,7 @@ class DitaTopic < Asciidoctor::Converter::Base
         logger.warn format_message "Possible invalid reference: #{node.target}" if node.target.include? '#'
 
         # Compose a cross reference:
-        return %(<xref href="#{node.target}">#{node.text || path}</xref>)
+        return %(<xref href="#{node.target}"#{compose_metadata node}>#{node.text || path}</xref>)
       end
 
       # Determine whether the ID reference target is in this document:
@@ -320,18 +320,18 @@ class DitaTopic < Asciidoctor::Converter::Base
         # Determine whether the ID reference target is the document id:
         if target == node.document.id
           # Compose the unchanged cross reference:
-          return node.text ? %(<xref href="##{target}">#{node.text}</xref>) : %(<xref href="##{target}" />)
+          return node.text ? %(<xref href="##{target}"#{compose_metadata node}>#{node.text}</xref>) : %(<xref href="##{target}" />)
         end
 
         # Compose the adjusted cross reference:
-        return node.text ? %(<xref href="#./#{target}">#{node.text}</xref>) : %(<xref href="#./#{target}" />)
+        return node.text ? %(<xref href="#./#{target}"#{compose_metadata node}>#{node.text}</xref>) : %(<xref href="#./#{target}" />)
       end
 
       # Issue a warning as the cross reference is unlikely to work:
       logger.warn format_message "Possible invalid reference: #{node.target}"
 
       # Compose the cross reference:
-      node.text ? %(<xref href="#{node.target}">#{node.text}</xref>) : %(<xref href="#{node.target}" />)
+      node.text ? %(<xref href="#{node.target}"#{compose_metadata node}>#{node.text}</xref>) : %(<xref href="#{node.target}" />)
     when :ref
       # NOTE: DITA does not have a dedicated element for inline anchors or
       # a direct equivalent of the <span> element from HTML. The solution
@@ -403,7 +403,7 @@ class DitaTopic < Asciidoctor::Converter::Base
     height  = '' if height.include? '%'
 
     # Return the XML output:
-    %(<image href="#{node.image_uri node.target}"#{width}#{height} placement="inline"><alt>#{node.alt}</alt></image>)
+    %(<image href="#{node.image_uri node.target}"#{width}#{height} placement="inline"#{compose_metadata node}><alt>#{node.alt}</alt></image>)
   end
 
   def convert_inline_indexterm node

--- a/test/test_inline_anchor.rb
+++ b/test/test_inline_anchor.rb
@@ -96,4 +96,55 @@ class InlineAnchorTest < Minitest::Test
     assert_xpath_equal xml, 'with custom text', '//xref[@href="#xref-macro"]/text()'
     assert_xpath_equal xml, 'file references', '//xref[@href="file.dita"]/text()'
   end
+
+  def test_external_link_role
+    xml = <<~EOF.chomp.to_dita
+    A paragraph with an link:https://example.com[external link,role="platform:linux"].
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//xref/@platform'
+  end
+
+  def test_xref_to_file_role
+    xml = <<~EOF.chomp.to_dita
+    Cross reference to xref:file.adoc[an external file,role="platform:linux"].
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//xref/@platform'
+  end
+
+  def test_xref_to_document_id_role
+    xml = <<~EOF.chomp.to_dita
+    [#topic-title]
+    = Topic title
+
+    Cross reference to xref:topic-title[an anchor,role="platform:linux"] within the same document.
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//xref/@platform'
+  end
+
+  def test_xref_to_inside_anchor_role
+    xml = <<~EOF.chomp.to_dita
+    [#topic-title]
+    = Topic title
+
+    Cross reference to xref:section-title[an anchor,role="platform:linux"] within the same document.
+
+    [#section-title]
+    == Section
+
+    Sample text.
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//xref/@platform'
+  end
+
+  def test_xref_to_anchor_role
+    xml = <<~EOF.chomp.to_dita
+    Cross references can look like xref:this[this,role="platform:linux"].
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//xref/@platform'
+  end
 end

--- a/test/test_inline_image.rb
+++ b/test/test_inline_image.rb
@@ -47,4 +47,12 @@ class InlineImageTest < Minitest::Test
     assert_xpath_count xml, 0, '//p/image[@href="image-3.png"]/@width'
     assert_xpath_count xml, 0, '//p/image[@href="image-3.png"]/@height'
   end
+
+  def test_image_role
+    xml = <<~EOF.chomp.to_dita
+    A paragraph with an image:image.png[image,role="platform:linux"].
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//p/image/@platform'
+  end
 end


### PR DESCRIPTION
DITA 1.3 supports [four metadata attributes for conditional processing](https://docs.oasis-open.org/dita/dita/v1.3/errata02/os/complete/part3-all-inclusive/langRef/attributes/metadataAttributes.html): platform, product, audience, and otherprops. This pull requests implements a mechanism which allows you to use [the role attribute](https://docs.asciidoctor.org/asciidoc/latest/attributes/role/) in AsciiDoc to propagate these four metadata attributes to [links](https://docs.asciidoctor.org/asciidoc/latest/macros/link-macro/), [cross references](https://docs.asciidoctor.org/asciidoc/latest/macros/xref/), and [inline images](https://docs.asciidoctor.org/asciidoc/latest/macros/images/#inline-image-macro) in the DITA output.

This pull request complements #19 which introduced this functionality for the rest of the AsciiDoc markup.

### Example AsciiDoc code

```asciidoc
A paragraph with an link:https://example.com[external link,role="platform:linux"].

A cross reference to xref:section-title[an anchor,role="platform:linux"] within the same document.

A cross reference to xref:file.adoc[an external file,role="platform:linux"].

A paragraph with an image:image.png[image,role="platform:linux"].
```

### Example DITA output

```xml
<p>A paragraph with an <xref href="https://example.com" scope="external" platform="linux">external link</xref>.</p>
<p>A cross reference to <xref href="#./section-title" platform="linux">an anchor</xref> within the same document.</p>
<p>A cross reference to <xref href="file.dita" platform="linux">an external file</xref>.</p>
<p>A paragraph with an <image href="image.png" placement="inline" platform="linux"><alt>image</alt></image>.</p>
```