### PR TITLE
Added support for metadata attributes to inline text span

### DIFF
--- a/lib/dita-topic.rb
+++ b/lib/dita-topic.rb
@@ -501,7 +501,7 @@ class DitaTopic < Asciidoctor::Converter::Base
       # Add comments around the STEM content:
       %(<!-- latexmath start -->#{node.text}<!-- latexmath end -->)
     else
-      node.text
+      %(<ph#{compose_metadata node}>#{node.text}</ph>)
     end
   end
 

--- a/test/test_inline_quoted.rb
+++ b/test/test_inline_quoted.rb
@@ -72,6 +72,15 @@ class InlineQuotedTest < Minitest::Test
     assert_xpath_equal xml, 'a variable', '//li[5]/varname/text()'
   end
 
+  def test_text_span
+    xml = <<~EOF.chomp.to_dita
+    A line with #inline text span#.
+    EOF
+
+    assert_xpath_equal xml, 'inline text span', '//ph/text()'
+  end
+
+
   def test_markup_roles
     xml = <<~EOF.chomp.to_dita
     Inline markup for [.platform:linux]_emphasis_, [.platform:linux]*strong*, [.platform:linux]`monospace`,
@@ -83,6 +92,14 @@ class InlineQuotedTest < Minitest::Test
     assert_xpath_equal xml, 'linux', '//codeph/@platform'
     assert_xpath_equal xml, 'linux', '//sup/@platform'
     assert_xpath_equal xml, 'linux', '//sub/@platform'
+  end
+
+  def test_text_span_roles
+    xml = <<~EOF.chomp.to_dita
+    A line with [.platform:linux]#inline text span#.
+    EOF
+
+    assert_xpath_equal xml, 'linux', '//ph/@platform'
   end
 
   def test_semantic_markup_roles


### PR DESCRIPTION
DITA 1.3 supports [four metadata attributes for conditional processing](https://docs.oasis-open.org/dita/dita/v1.3/errata02/os/complete/part3-all-inclusive/langRef/attributes/metadataAttributes.html): platform, product, audience, and otherprops. This pull requests implements a mechanism which allows you to use [the role attribute](https://docs.asciidoctor.org/asciidoc/latest/attributes/role/) in AsciiDoc to propagate these four metadata attributes to [inline text span](https://docs.asciidoctor.org/asciidoc/latest/text/text-span-built-in-roles/).

This pull request complements #19 and #20.

### Example AsciiDoc code

```asciidoc
A line with [.platform:linux]#inline text span#.
```

### Example DITA output

```xml
<p>A line with <ph platform="linux">inline text span</ph>.</p>
```