### PR TITLE
Add support for the id attribute to all valid elements

### DIFF
--- a/lib/dita-topic.rb
+++ b/lib/dita-topic.rb
@@ -297,7 +297,7 @@ class DitaTopic < Asciidoctor::Converter::Base
     case node.type
     when :link
       # Compose an external link:
-      %(<xref href="#{node.target}" scope="external"#{compose_metadata node.role}>#{node.text}</xref>)
+      %(<xref href="#{node.target}" scope="external"#{compose_id node.id}#{compose_metadata node.role}>#{node.text}</xref>)
     when :xref
       # NOTE: While AsciiDoc is happy to reference an ID that is not
       # defined in the same AsciiDoc file, DITA requires the topic ID as

--- a/lib/dita-topic.rb
+++ b/lib/dita-topic.rb
@@ -453,9 +453,9 @@ class DitaTopic < Asciidoctor::Converter::Base
     # Determine the inline markup type:
     case node.type
     when :emphasis
-      %(<i#{compose_metadata node.role}>#{node.text}</i>)
+      %(<i#{compose_id node.id}#{compose_metadata node.role}>#{node.text}</i>)
     when :strong
-      %(<b#{compose_metadata node.role}>#{node.text}</b>)
+      %(<b#{compose_id node.id}#{compose_metadata node.role}>#{node.text}</b>)
     when :monospaced
       # Set the default element value:
       element = 'codeph'
@@ -479,11 +479,11 @@ class DitaTopic < Asciidoctor::Converter::Base
       end
 
       # Return the result:
-      %(<#{element}#{compose_metadata node.role}>#{node.text}</#{element}>)
+      %(<#{element}#{compose_id node.id}#{compose_metadata node.role}>#{node.text}</#{element}>)
     when :superscript
-      %(<sup#{compose_metadata node.role}>#{node.text}</sup>)
+      %(<sup#{compose_id node.id}#{compose_metadata node.role}>#{node.text}</sup>)
     when :subscript
-      %(<sub#{compose_metadata node.role}>#{node.text}</sub>)
+      %(<sub#{compose_id node.id}#{compose_metadata node.role}>#{node.text}</sub>)
     when :double
       %(&#8220;#{node.text}&#8221;)
     when :single
@@ -501,7 +501,7 @@ class DitaTopic < Asciidoctor::Converter::Base
       # Add comments around the STEM content:
       %(<!-- latexmath start -->#{node.text}<!-- latexmath end -->)
     else
-      %(<ph#{compose_metadata node.role}>#{node.text}</ph>)
+      %(<ph#{compose_id node.id}#{compose_metadata node.role}>#{node.text}</ph>)
     end
   end
 

--- a/lib/dita-topic.rb
+++ b/lib/dita-topic.rb
@@ -130,7 +130,7 @@ class DitaTopic < Asciidoctor::Converter::Base
 
     # Return the XML output:
     <<~EOF.chomp
-    <note type="#{node.attr 'name'}"#{compose_metadata node.role}>#{node.content}</note>
+    <note type="#{node.attr 'name'}"#{compose_id node.id}#{compose_metadata node.role}>#{node.content}</note>
     EOF
   end
 
@@ -138,12 +138,12 @@ class DitaTopic < Asciidoctor::Converter::Base
     # Check if the audio macro has a title specified:
     if node.title?
       <<~EOF.chomp
-      <object data="#{node.media_uri(node.attr 'target')}"#{compose_metadata node.role}>
+      <object data="#{node.media_uri(node.attr 'target')}"#{compose_id node.id}#{compose_metadata node.role}>
         <desc>#{node.title}</desc>
       </object>
       EOF
     else
-      %(<object data="#{node.media_uri(node.attr 'target')}"#{compose_metadata node.role} />)
+      %(<object data="#{node.media_uri(node.attr 'target')}"#{compose_id node.id}#{compose_metadata node.role} />)
     end
   end
 
@@ -158,7 +158,7 @@ class DitaTopic < Asciidoctor::Converter::Base
     number = 0
 
     # Open the definition list:
-    result = [%(<dl outputclass="callout-list"#{compose_metadata node.role}>)]
+    result = [%(<dl outputclass="callout-list"#{compose_id node.id}#{compose_metadata node.role}>)]
 
     # Process individual list items:
     node.items.each do |item|
@@ -198,7 +198,7 @@ class DitaTopic < Asciidoctor::Converter::Base
     return compose_qanda_dlist node if node.style == 'qanda'
 
     # Open the definition list:
-    result = [%(<dl#{compose_metadata node.role}>)]
+    result = [%(<dl#{compose_id node.id}#{compose_metadata node.role}>)]
 
     # Process individual list items:
     node.items.each do |terms, description|
@@ -260,7 +260,7 @@ class DitaTopic < Asciidoctor::Converter::Base
     end
 
     # Return the XML output:
-    %(<p outputclass="title sect#{node.level}"#{compose_metadata node.role}><b>#{node.title}</b></p>)
+    %(<p outputclass="title sect#{node.level}"#{compose_id node.id}#{compose_metadata node.role}><b>#{node.title}</b></p>)
   end
 
   def convert_image node
@@ -276,7 +276,7 @@ class DitaTopic < Asciidoctor::Converter::Base
     # Check if the image has a title specified:
     if node.title?
       <<~EOF.chomp
-      <fig#{compose_metadata node.role}>
+      <fig#{compose_id node.id}#{compose_metadata node.role}>
       <title>#{node.title}</title>
       <image href="#{node.image_uri(node.attr 'target')}"#{width}#{height}#{scale} placement="break">
       <alt>#{node.alt}</alt>
@@ -285,7 +285,7 @@ class DitaTopic < Asciidoctor::Converter::Base
       EOF
     else
       <<~EOF.chomp
-      <image href="#{node.image_uri(node.attr 'target')}"#{width}#{height}#{scale} placement="break"#{compose_metadata node.role}>
+      <image href="#{node.image_uri(node.attr 'target')}"#{width}#{height}#{scale} placement="break"#{compose_id node.id}#{compose_metadata node.role}>
       <alt>#{node.alt}</alt>
       </image>
       EOF
@@ -510,11 +510,7 @@ class DitaTopic < Asciidoctor::Converter::Base
     language = (node.attributes.key? 'language') ? %( outputclass="language-#{node.attributes['language']}") : ''
 
     # Compose the XML output:
-    result = <<~EOF.chomp
-    <codeblock#{language}#{compose_metadata node.role}>
-    #{node.content}
-    </codeblock>
-    EOF
+    result = %(<codeblock#{language}#{compose_id node.id}#{compose_metadata node.role}>#{node.content}</codeblock>)
 
     # Return the XML output:
     add_block_title result, node
@@ -522,11 +518,7 @@ class DitaTopic < Asciidoctor::Converter::Base
 
   def convert_literal node
     # Compose the XML output:
-    result = <<~EOF.chomp
-    <pre#{compose_metadata node.role}>
-    #{node.content}
-    </pre>
-    EOF
+    result = %(<pre#{compose_id node.id}#{compose_metadata node.role}>#{node.content}</pre>)
 
     # Return the XML output:
     add_block_title result, node
@@ -534,17 +526,17 @@ class DitaTopic < Asciidoctor::Converter::Base
 
   def convert_olist node
     # Open the ordered list:
-    result = [%(<ol#{compose_metadata node.role}>)]
+    result = [%(<ol#{compose_id node.id}#{compose_metadata node.role}>)]
 
     # Process individual list items:
     node.items.each do |item|
       # Check if the list item contains multiple block elements:
       if item.blocks?
-        result << %(<li#{compose_metadata item.role}>#{item.text})
+        result << %(<li#{compose_id item.id}#{compose_metadata item.role}>#{item.text})
         result << item.content
         result << %(</li>)
       else
-        result << %(<li#{compose_metadata item.role}>#{item.text}</li>)
+        result << %(<li#{compose_id item.id}#{compose_metadata item.role}>#{item.text}</li>)
       end
     end
 
@@ -566,12 +558,12 @@ class DitaTopic < Asciidoctor::Converter::Base
       node.content
     elsif node.content_model == :compound
       <<~EOF.chomp
-      <div#{(node.style == 'abstract') ? ' outputclass="abstract"' : ''}#{compose_metadata node.role}>
+      <div#{(node.style == 'abstract') ? ' outputclass="abstract"' : ''}#{compose_id node.id}#{compose_metadata node.role}>
       #{compose_floating_title node.title}#{node.content}
       </div>
       EOF
     else
-      %(#{compose_floating_title node.title}<p#{(node.style == 'abstract') ? ' outputclass="abstract"' : ''}#{compose_metadata node.role}>#{node.content}</p>)
+      %(#{compose_floating_title node.title}<p#{(node.style == 'abstract') ? ' outputclass="abstract"' : ''}#{compose_id node.id}#{compose_metadata node.role}>#{node.content}</p>)
     end
   end
 
@@ -587,9 +579,9 @@ class DitaTopic < Asciidoctor::Converter::Base
 
   def convert_paragraph node
     if (node.attr 'role') and (node.attr 'role').split.include? '_abstract'
-      add_block_title %(<p outputclass="abstract"#{compose_metadata node.role}>#{node.content}</p>), node
+      add_block_title %(<p outputclass="abstract"#{compose_id node.id}#{compose_metadata node.role}>#{node.content}</p>), node
     else
-      add_block_title %(<p#{compose_metadata node.role}>#{node.content}</p>), node
+      add_block_title %(<p#{compose_id node.id}#{compose_metadata node.role}>#{node.content}</p>), node
     end
   end
 
@@ -607,13 +599,13 @@ class DitaTopic < Asciidoctor::Converter::Base
     # Check if the content contains multiple block elements:
     if node.content_model == :compound
       <<~EOF.chomp
-      <lq#{compose_metadata node.role}>
+      <lq#{compose_id node.id}#{compose_metadata node.role}>
       #{compose_floating_title node.title}#{node.content}#{author}#{source}
       </lq>
       EOF
     else
       <<~EOF.chomp
-      <lq#{compose_metadata node.role}>
+      <lq#{compose_id node.id}#{compose_metadata node.role}>
       #{compose_floating_title node.title}<p>#{node.content}</p>#{author}#{source}
       </lq>
       EOF
@@ -659,13 +651,13 @@ class DitaTopic < Asciidoctor::Converter::Base
     # Check if the content contains multiple block elements:
     if node.content_model == :compound
       <<~EOF.chomp
-      <div outputclass="sidebar"#{compose_metadata node.role}>
+      <div outputclass="sidebar"#{compose_id node.id}#{compose_metadata node.role}>
       #{compose_floating_title node.title}#{node.content}
       </div>
       EOF
     else
       <<~EOF.chomp
-      <div outputclass="sidebar"#{compose_metadata node.role}>
+      <div outputclass="sidebar"#{compose_id node.id}#{compose_metadata node.role}>
       #{compose_floating_title node.title}<p>#{node.content}</p>
       </div>
       EOF
@@ -680,7 +672,7 @@ class DitaTopic < Asciidoctor::Converter::Base
 
   def convert_table node
     # Open the table:
-    result = [%(<table#{compose_metadata node.role}>)]
+    result = [%(<table#{compose_id node.id}#{compose_metadata node.role}>)]
 
     # Check if the title is specified:
     result << %(<title>#{node.title}</title>) if node.title?
@@ -770,7 +762,7 @@ class DitaTopic < Asciidoctor::Converter::Base
 
   def convert_ulist node
     # Open the unordered list:
-    result = [%(<ul#{compose_metadata node.role}>)]
+    result = [%(<ul#{compose_id node.id}#{compose_metadata node.role}>)]
 
     # Process individual list items:
     node.items.each do |item|
@@ -783,11 +775,11 @@ class DitaTopic < Asciidoctor::Converter::Base
 
       # Check if the list item contains multiple block elements:
       if item.blocks?
-        result << %(<li#{compose_metadata item.role}>#{check_box}#{item.text})
+        result << %(<li#{compose_id item.id}#{compose_metadata item.role}>#{check_box}#{item.text})
         result << item.content
         result << %(</li>)
       else
-        result << %(<li#{compose_metadata item.role}>#{check_box}#{item.text}</li>)
+        result << %(<li#{compose_id item.id}#{compose_metadata item.role}>#{check_box}#{item.text}</li>)
       end
     end
 
@@ -807,7 +799,7 @@ class DitaTopic < Asciidoctor::Converter::Base
 
     # Return the XML output:
     <<~EOF.chomp
-    <lines#{compose_metadata node.role}>
+    <lines#{compose_id node.id}#{compose_metadata node.role}>
     #{node.content}#{author}#{source}
     </lines>
     EOF
@@ -842,18 +834,18 @@ class DitaTopic < Asciidoctor::Converter::Base
     # Check if the audio macro has a title specified:
     if node.title?
       <<~EOF.chomp
-      <object data="#{target_url}"#{width}#{height}#{compose_metadata node.role}>
+      <object data="#{target_url}"#{width}#{height}#{compose_id node.id}#{compose_metadata node.role}>
         <desc>#{node.title}</desc>
       </object>
       EOF
     else
-      %(<object data="#{target_url}"#{width}#{height}#{compose_metadata node.role} />)
+      %(<object data="#{target_url}"#{width}#{height}#{compose_id node.id}#{compose_metadata node.role} />)
     end
   end
 
   def compose_qanda_dlist node
     # Open the ordered list:
-    result = [%(<ol#{compose_metadata node.role}>)]
+    result = [%(<ol#{compose_id node.id}#{compose_metadata node.role}>)]
 
     # Process individual list items:
     node.items.each do |terms, description|
@@ -884,7 +876,7 @@ class DitaTopic < Asciidoctor::Converter::Base
 
   def compose_horizontal_dlist node
     # Open the table:
-    result = [%(<table outputclass="horizontal-dlist"#{compose_metadata node.role}>)]
+    result = [%(<table outputclass="horizontal-dlist"#{compose_id node.id}#{compose_metadata node.role}>)]
 
     # Check if the title is specified:
     result << %(<title>#{node.title}</title>) if node.title?

--- a/test/test_admonition.rb
+++ b/test/test_admonition.rb
@@ -101,4 +101,21 @@ class AdmonitionTest < Minitest::Test
 
     assert_xpath_count xml, 0, '//note/@platform'
   end
+
+  def test_admonition_id
+    xml = <<~EOF.chomp.to_dita
+    [#admonition-id]
+    TIP: This is a tip.
+    EOF
+
+    assert_xpath_equal xml, 'admonition-id', '//note/@id'
+  end
+
+  def test_admonition_no_id
+    xml = <<~EOF.chomp.to_dita
+    TIP: This is a tip.
+    EOF
+
+    assert_xpath_count xml, 0, '//note/@id'
+  end
 end

--- a/test/test_audio.rb
+++ b/test/test_audio.rb
@@ -38,4 +38,40 @@ class AudioTest < Minitest::Test
 
     assert_xpath_equal xml, 'linux', '//object/@platform'
   end
+
+  def test_audio_id
+    xml = <<~EOF.chomp.to_dita
+    [#audio-id]
+    audio::audio.wav[]
+    EOF
+
+    assert_xpath_equal xml, 'audio-id', '//object/@id'
+  end
+
+  def test_audio_id_with_title
+    xml = <<~EOF.chomp.to_dita
+    [#audio-id]
+    .Audio title
+    audio::audio.wav[]
+    EOF
+
+    assert_xpath_equal xml, 'audio-id', '//object/@id'
+  end
+
+  def test_audio_no_id
+    xml = <<~EOF.chomp.to_dita
+    audio::audio.wav[]
+    EOF
+
+    assert_xpath_count xml, 0, '//object/@id'
+  end
+
+  def test_audio_no_id_with_title
+    xml = <<~EOF.chomp.to_dita
+    .Audio title
+    audio::audio.wav[]
+    EOF
+
+    assert_xpath_count xml, 0, '//object/@id'
+  end
 end

--- a/test/test_colist.rb
+++ b/test/test_colist.rb
@@ -41,8 +41,6 @@ class ColistTest < Minitest::Test
 
   def test_colist_role
     xml = <<~EOF.chomp.to_dita
-    :dita-topic-callouts: on
-
     ----
     Code line <1>
     ----
@@ -51,5 +49,28 @@ class ColistTest < Minitest::Test
     EOF
 
     assert_xpath_equal xml, 'linux', '//dl/@platform'
+  end
+
+  def test_colist_id
+    xml = <<~EOF.chomp.to_dita
+    ----
+    Code line <1>
+    ----
+    [#colist-id]
+    <1> Code description
+    EOF
+
+    assert_xpath_equal xml, 'colist-id', '//dl/@id'
+  end
+
+  def test_colist_no_id
+    xml = <<~EOF.chomp.to_dita
+    ----
+    Code line <1>
+    ----
+    <1> Code description
+    EOF
+
+    assert_xpath_count xml, 0, '//dl/@id'
   end
 end

--- a/test/test_dlist.rb
+++ b/test/test_dlist.rb
@@ -72,4 +72,25 @@ class DlistTest < Minitest::Test
     assert_xpath_equal xml, 'linux', '//dl/@platform'
     assert_xpath_equal xml, 'linux', '//p[@outputclass="title"]/@platform'
   end
+
+  def test_description_list_id
+    xml = <<~EOF.chomp.to_dita
+    [#dlist-id]
+    .A description list title
+    Term1:: Definition one
+    Term2:: Definition two
+    EOF
+
+    assert_xpath_equal xml, 'dlist-id', '//dl/@id'
+    assert_xpath_count xml, 0, '//p[@outputclass="title"]/@id'
+  end
+
+  def test_description_list_no_id
+    xml = <<~EOF.chomp.to_dita
+    Term1:: Definition one
+    Term2:: Definition two
+    EOF
+
+    assert_xpath_count xml, 0, '//dl/@id'
+  end
 end

--- a/test/test_example.rb
+++ b/test/test_example.rb
@@ -21,17 +21,6 @@ class ExampleTest < Minitest::Test
     assert_xpath_equal xml, 'An example block', '//example/p/text()'
   end
 
-  def test_example_block_id
-    xml = <<~EOF.chomp.to_dita
-    [#example-id]
-    ====
-    An example block
-    ====
-    EOF
-
-    assert_xpath_equal xml, 'example-id', '//example/@id'
-  end
-
   def test_example_block_title
     xml = <<~EOF.chomp.to_dita
     .An example block title
@@ -53,5 +42,26 @@ class ExampleTest < Minitest::Test
     EOF
 
     assert_xpath_equal xml, 'linux', '//example/@platform'
+  end
+
+  def test_example_block_id
+    xml = <<~EOF.chomp.to_dita
+    [#example-id]
+    ====
+    An example block
+    ====
+    EOF
+
+    assert_xpath_equal xml, 'example-id', '//example/@id'
+  end
+
+  def test_example_block_no_id
+    xml = <<~EOF.chomp.to_dita
+    ====
+    An example block
+    ====
+    EOF
+
+    assert_xpath_count xml, 0, '//example/@id'
   end
 end

--- a/test/test_floating_title.rb
+++ b/test/test_floating_title.rb
@@ -39,4 +39,13 @@ class FloatingTitleTest < Minitest::Test
 
     assert_xpath_equal xml, 'linux', '//p[@outputclass="title sect1"]/@platform'
   end
+
+  def test_section_id
+    xml = <<~EOF.chomp.to_dita
+    [discrete,id="section-id"]
+    == Section 1
+    EOF
+
+    assert_xpath_equal xml, 'section-id', '//p[@outputclass="title sect1"]/@id'
+  end
 end

--- a/test/test_horizontal_dlist.rb
+++ b/test/test_horizontal_dlist.rb
@@ -58,4 +58,24 @@ class HorizontalDlistTest < Minitest::Test
 
     assert_xpath_equal xml, 'linux', '//table/@platform'
   end
+
+  def test_horizontal_dlist_id
+    xml = <<~EOF.chomp.to_dita
+    [horizontal,id="list-id"]
+    Term1:: Definition one
+    Term2:: Definition two
+    EOF
+
+    assert_xpath_equal xml, 'list-id', '//table/@id'
+  end
+
+  def test_horizontal_dlist_no_id
+    xml = <<~EOF.chomp.to_dita
+    [horizontal]
+    Term1:: Definition one
+    Term2:: Definition two
+    EOF
+
+    assert_xpath_count xml, 0, '//table/@id'
+  end
 end

--- a/test/test_image.rb
+++ b/test/test_image.rb
@@ -87,4 +87,40 @@ class ImageTest < Minitest::Test
 
     assert_xpath_equal xml, 'linux', '//fig/@platform'
   end
+
+  def test_image_id
+    xml = <<~EOF.chomp.to_dita
+    [#image-id]
+    image::image.png[]
+    EOF
+
+    assert_xpath_equal xml, 'image-id', '//image/@id'
+  end
+
+  def test_image_id_with_title
+    xml = <<~EOF.chomp.to_dita
+    [#image-id]
+    .Image title
+    image::image.png[]
+    EOF
+
+    assert_xpath_equal xml, 'image-id', '//fig/@id'
+  end
+
+  def test_image_no_id
+    xml = <<~EOF.chomp.to_dita
+    image::image.png[]
+    EOF
+
+    assert_xpath_count xml, 0, '//image/@id'
+  end
+
+  def test_image_no_id_with_title
+    xml = <<~EOF.chomp.to_dita
+    .Image title
+    image::image.png[]
+    EOF
+
+    assert_xpath_count xml, 0, '//fig/@id'
+  end
 end

--- a/test/test_inline_anchor.rb
+++ b/test/test_inline_anchor.rb
@@ -147,4 +147,20 @@ class InlineAnchorTest < Minitest::Test
 
     assert_xpath_equal xml, 'linux', '//xref/@platform'
   end
+
+  def test_external_link_id
+    xml = <<~EOF.chomp.to_dita
+    A paragraph with an link:https://example.com[external link,id="link-id"].
+    EOF
+
+    assert_xpath_equal xml, 'link-id', '//xref/@id'
+  end
+
+  def test_external_link_no_id
+    xml = <<~EOF.chomp.to_dita
+    A paragraph with an link:https://example.com[external link].
+    EOF
+
+    assert_xpath_count xml, 0, '//xref/@id'
+  end
 end

--- a/test/test_inline_quoted.rb
+++ b/test/test_inline_quoted.rb
@@ -80,7 +80,6 @@ class InlineQuotedTest < Minitest::Test
     assert_xpath_equal xml, 'inline text span', '//ph/text()'
   end
 
-
   def test_markup_roles
     xml = <<~EOF.chomp.to_dita
     Inline markup for [.platform:linux]_emphasis_, [.platform:linux]*strong*, [.platform:linux]`monospace`,
@@ -116,5 +115,80 @@ class InlineQuotedTest < Minitest::Test
     assert_xpath_equal xml, 'linux', '//li[3]/filepath/@platform'
     assert_xpath_equal xml, 'linux', '//li[4]/option/@platform'
     assert_xpath_equal xml, 'linux', '//li[5]/varname/@platform'
+  end
+
+  def test_markup_id
+    xml = <<~EOF.chomp.to_dita
+    Inline markup for [#emphasis-id]_emphasis_, [#strong-id]*strong*,
+    [#monospace-id]`monospace`, [#superscript-id]^superscript^, and
+    [#subscript-id]~subscript~.
+    EOF
+
+    assert_xpath_equal xml, 'emphasis-id', '//i/@id'
+    assert_xpath_equal xml, 'strong-id', '//b/@id'
+    assert_xpath_equal xml, 'monospace-id', '//codeph/@id'
+    assert_xpath_equal xml, 'superscript-id', '//sup/@id'
+    assert_xpath_equal xml, 'subscript-id', '//sub/@id'
+  end
+
+  def test_text_span_id
+    xml = <<~EOF.chomp.to_dita
+    A line with [#span-id]#inline text span#.
+    EOF
+
+    assert_xpath_equal xml, 'span-id', '//ph/@id'
+  end
+
+  def test_semantic_markup_id
+    xml = <<~EOF.chomp.to_dita
+    * [#command-id.command]`a command`
+    * [#directory-id.directory]`a directory name`
+    * [#filename-id.filename]`a file name`
+    * [#option-id.option]`an option`
+    * [#variable-id.variable]`a variable`
+    EOF
+
+    assert_xpath_equal xml, 'command-id', '//li[1]/cmdname/@id'
+    assert_xpath_equal xml, 'directory-id', '//li[2]/filepath/@id'
+    assert_xpath_equal xml, 'filename-id', '//li[3]/filepath/@id'
+    assert_xpath_equal xml, 'option-id', '//li[4]/option/@id'
+    assert_xpath_equal xml, 'variable-id', '//li[5]/varname/@id'
+  end
+
+  def test_markup_no_id
+    xml = <<~EOF.chomp.to_dita
+    Inline markup for _emphasis_, *strong*, `monospace`, ^superscript^,
+    and ~subscript~.
+    EOF
+
+    assert_xpath_count xml, 0, '//i/@id'
+    assert_xpath_count xml, 0, '//b/@id'
+    assert_xpath_count xml, 0, '//codeph/@id'
+    assert_xpath_count xml, 0, '//sup/@id'
+    assert_xpath_count xml, 0, '//sub/@id'
+  end
+
+  def test_text_span_no_id
+    xml = <<~EOF.chomp.to_dita
+    A line with #inline text span#.
+    EOF
+
+    assert_xpath_count xml, 0, '//ph/@id'
+  end
+
+  def test_semantic_markup_no_id
+    xml = <<~EOF.chomp.to_dita
+    * `a command`
+    * `a directory name`
+    * `a file name`
+    * `an option`
+    * `a variable`
+    EOF
+
+    assert_xpath_count xml, 0, '//li[1]/cmdname/@id'
+    assert_xpath_count xml, 0, '//li[2]/filepath/@id'
+    assert_xpath_count xml, 0, '//li[3]/filepath/@id'
+    assert_xpath_count xml, 0, '//li[4]/option/@id'
+    assert_xpath_count xml, 0, '//li[5]/varname/@id'
   end
 end

--- a/test/test_listing.rb
+++ b/test/test_listing.rb
@@ -87,4 +87,24 @@ class ListingTest < Minitest::Test
     assert_xpath_equal xml, 'linux', '//codeblock/@platform'
     assert_xpath_equal xml, 'linux', '//p[@outputclass="title"]/@platform'
   end
+
+  def test_source_block_id
+    xml = <<~EOF.chomp.to_dita
+    [source,id="source-id"]
+    .A listing block title
+    A source code block
+    EOF
+
+    assert_xpath_equal xml, 'source-id', '//codeblock/@id'
+    assert_xpath_count xml, 0, '//p[@outputclass="title"]/@id'
+  end
+
+  def test_source_block_no_id
+    xml = <<~EOF.chomp.to_dita
+    [source]
+    A source code block
+    EOF
+
+    assert_xpath_count xml, 0, '//codeblock/@id'
+  end
 end

--- a/test/test_literal.rb
+++ b/test/test_literal.rb
@@ -52,4 +52,24 @@ class LiteralTest < Minitest::Test
     assert_xpath_equal xml, 'linux', '//pre/@platform'
     assert_xpath_equal xml, 'linux', '//p[@outputclass="title"]/@platform'
   end
+
+  def test_literal_block_id
+    xml = <<~EOF.chomp.to_dita
+    [literal,id="literal-id"]
+    .A literal block title
+    A literal block
+    EOF
+
+    assert_xpath_equal xml, 'literal-id', '//pre/@id'
+    assert_xpath_count xml, 0, '//p[@outputclass="title"]/@id'
+  end
+
+  def test_literal_block_no_id
+    xml = <<~EOF.chomp.to_dita
+    [literal]
+    A literal block
+    EOF
+
+    assert_xpath_count xml, 0, '//pre/@id'
+  end
 end

--- a/test/test_olist.rb
+++ b/test/test_olist.rb
@@ -70,4 +70,67 @@ class OlistTest < Minitest::Test
     assert_xpath_equal xml, 'linux', '//ol[1]/li[1]/@platform'
     assert_xpath_equal xml, 'linux', '//ol[2]/li[1]/@platform'
   end
+
+  def test_ordered_list_id
+    xml = <<~EOF.chomp.to_dita
+    [#list-id]
+    .An ordered list title
+    . Item one
+    . Item two
+    EOF
+
+    assert_xpath_equal xml, 'list-id', '//ol/@id'
+    assert_xpath_count xml, 0, '//ol/li/@id'
+    assert_xpath_count xml, 0, '//p[@outputclass="title"]/@id'
+  end
+
+  def test_ordered_list_no_id
+    xml = <<~EOF.chomp.to_dita
+    . Item one
+    . Item two
+    EOF
+
+    assert_xpath_count xml, 0, '//ol/@id'
+  end
+
+  def test_ordered_list_item_id
+    doc = <<~EOF.chomp.parse_adoc
+    . Item one
+    . Item two
+
+    // A comment separates two lists
+
+    . Item one
+    +
+    Additional paragraph
+
+    . Item two
+    EOF
+
+    first_list = doc.blocks[0]
+    first_list.items[0].id = 'first-id'
+    second_list = doc.blocks[1]
+    second_list.items[0].id = 'second-id'
+    xml = doc.convert
+
+    assert_xpath_equal xml, 'first-id', '//ol[1]/li[1]/@id'
+    assert_xpath_equal xml, 'second-id', '//ol[2]/li[1]/@id'
+  end
+
+  def test_ordered_list_item_no_id
+    xml = <<~EOF.chomp.to_dita
+    . Item one
+    . Item two
+
+    // A comment separates two lists
+
+    . Item one
+    +
+    Additional paragraph
+
+    . Item two
+    EOF
+
+    assert_xpath_count xml, 0, '//ol/li/@id'
+  end
 end

--- a/test/test_open.rb
+++ b/test/test_open.rb
@@ -116,4 +116,85 @@ class OpenTest < Minitest::Test
 
     assert_xpath_equal xml, 'linux', '//body/section/p/@platform'
   end
+
+  def test_simple_abstract_id
+    xml = <<~EOF.chomp.to_dita
+    = A document header
+
+    [abstract,id="abstract-id"]
+    An abstract.
+    EOF
+
+    assert_xpath_equal xml, 'abstract-id', '//body/p/@id'
+  end
+
+  def test_compound_abstract_id
+    xml = <<~EOF.chomp.to_dita
+    = A document header
+
+    [abstract,id="abstract-id"]
+    --
+    An abstract.
+
+    An abstract continued.
+    --
+    EOF
+
+    assert_xpath_equal xml, 'abstract-id', '//body/div/@id'
+  end
+
+  def test_part_introduction_id
+    xml = <<~EOF.chomp.to_dita 'book'
+    = A document header
+
+    A paragraph.
+
+    = A part header
+
+    [#introduction-id]
+    A part introduction.
+    EOF
+
+    assert_xpath_equal xml, 'introduction-id', '//body/section/p/@id'
+  end
+
+  def test_simple_abstract_no_id
+    xml = <<~EOF.chomp.to_dita
+    = A document header
+
+    [abstract]
+    An abstract.
+    EOF
+
+    assert_xpath_count xml, 0, '//body/p/@id'
+  end
+
+  def test_compound_abstract_no_id
+    xml = <<~EOF.chomp.to_dita
+    = A document header
+
+    [abstract]
+    --
+    An abstract.
+
+    An abstract continued.
+    --
+    EOF
+
+    assert_xpath_count xml, 0, '//body/div/@id'
+  end
+
+  def test_part_introduction_no_id
+    xml = <<~EOF.chomp.to_dita 'book'
+    = A document header
+
+    A paragraph.
+
+    = A part header
+
+    A part introduction.
+    EOF
+
+    assert_xpath_count xml, 0, '//body/section/p/@id'
+  end
 end

--- a/test/test_paragraph.rb
+++ b/test/test_paragraph.rb
@@ -74,4 +74,47 @@ class ParagraphTest < Minitest::Test
     assert_xpath_equal xml, 'linux', '//p[2]/@platform'
     assert_xpath_equal xml, 'linux', '//p[1][@outputclass="title"]/@platform'
   end
+
+  def test_paragraph_id
+    xml = <<~EOF.chomp.to_dita
+    [#paragraph-id]
+    .A paragraph title
+    First paragraph.
+    EOF
+
+    assert_xpath_equal xml, 'paragraph-id', '//p[2]/@id'
+    assert_xpath_count xml, 0, '//p[1][@outputclass="title"]/@id'
+  end
+
+  def test_abstract_paragraph_id
+    xml = <<~EOF.chomp.to_dita
+    [role="_abstract",id="paragraph-id"]
+    .An abstract paragraph title
+    An abstract.
+
+    A paragraph.
+    EOF
+
+    assert_xpath_equal xml, 'paragraph-id', '//p[2]/@id'
+    assert_xpath_count xml, 0, '//p[1][@outputclass="title"]/@id'
+  end
+
+  def test_paragraph_no_id
+    xml = <<~EOF.chomp.to_dita
+    First paragraph.
+    EOF
+
+    assert_xpath_count xml, 0, '//p/@id'
+  end
+
+  def test_abstract_paragraph_no_id
+    xml = <<~EOF.chomp.to_dita
+    [role="_abstract"]
+    An abstract.
+
+    A paragraph.
+    EOF
+
+    assert_xpath_count xml, 0, '//p/@id'
+  end
 end

--- a/test/test_qanda_dlist.rb
+++ b/test/test_qanda_dlist.rb
@@ -55,4 +55,26 @@ class QuandaDlistTest < Minitest::Test
     assert_xpath_equal xml, 'linux', '//ol/@platform'
     assert_xpath_equal xml, 'linux', '//p[@outputclass="title"]/@platform'
   end
+
+  def test_qanda_list_id
+    xml = <<~EOF.chomp.to_dita
+    [qanda,id="list-id"]
+    .A quanda list title
+    Question 1:: Answer one
+    Question 2:: Answer two
+    EOF
+
+    assert_xpath_equal xml, 'list-id', '//ol/@id'
+    assert_xpath_count xml, 0, '//p[@outputclass="title"]/@id'
+  end
+
+  def test_qanda_list_no_id
+    xml = <<~EOF.chomp.to_dita
+    [qanda]
+    Question 1:: Answer one
+    Question 2:: Answer two
+    EOF
+
+    assert_xpath_count xml, 0, '//ol/@id'
+  end
 end

--- a/test/test_quote.rb
+++ b/test/test_quote.rb
@@ -82,4 +82,48 @@ class QuoteTest < Minitest::Test
 
     assert_xpath_equal xml, 'linux', '//lq/@platform'
   end
+
+  def test_quote_id
+    xml = <<~EOF.chomp.to_dita
+    [quote,Author Name,Quote source,id="quote-id"]
+    Quoted line
+    EOF
+
+    assert_xpath_equal xml, 'quote-id', '//lq/@id'
+  end
+
+  def test_delimited_quote_id
+    xml = <<~EOF.chomp.to_dita
+    [quote,Author Name,Quote source,id="quote-id"]
+    ____
+    First line
+
+    Second line
+    ____
+    EOF
+
+    assert_xpath_equal xml, 'quote-id', '//lq/@id'
+  end
+
+  def test_quote_no_id
+    xml = <<~EOF.chomp.to_dita
+    [quote,Author Name,Quote source]
+    Quoted line
+    EOF
+
+    assert_xpath_count xml, 0, '//lq/@id'
+  end
+
+  def test_delimited_quote_no_id
+    xml = <<~EOF.chomp.to_dita
+    [quote,Author Name,Quote source]
+    ____
+    First line
+
+    Second line
+    ____
+    EOF
+
+    assert_xpath_count xml, 0, '//lq/@id'
+  end
 end

--- a/test/test_sidebar.rb
+++ b/test/test_sidebar.rb
@@ -67,4 +67,43 @@ class SidebarTest < Minitest::Test
 
     assert_xpath_equal xml, 'linux', '//div/@platform'
   end
+
+  def test_sidebar_id
+    xml = <<~EOF.chomp.to_dita
+    [sidebar,id="sidebar-id"]
+    Sidebar text
+    EOF
+
+    assert_xpath_equal xml, 'sidebar-id', '//div/@id'
+  end
+
+  def test_delimited_sidebar_id
+    xml = <<~EOF.chomp.to_dita
+    [#sidebar-id]
+    ****
+    Sidebar text
+    ****
+    EOF
+
+    assert_xpath_equal xml, 'sidebar-id', '//div/@id'
+  end
+
+  def test_sidebar_no_id
+    xml = <<~EOF.chomp.to_dita
+    [sidebar]
+    Sidebar text
+    EOF
+
+    assert_xpath_count xml, 0, '//div/@id'
+  end
+
+  def test_delimited_sidebar_no_id
+    xml = <<~EOF.chomp.to_dita
+    ****
+    Sidebar text
+    ****
+    EOF
+
+    assert_xpath_count xml, 0, '//div/@id'
+  end
 end

--- a/test/test_table.rb
+++ b/test/test_table.rb
@@ -148,4 +148,32 @@ class TableTest < Minitest::Test
 
     assert_xpath_equal xml, 'linux', '//table/@platform'
   end
+
+  def test_table_id
+    xml = <<~EOF.chomp.to_dita
+    [cols="1, 1",id="table-id"]
+    |===
+    |Column 1 header|Column 2 header
+
+    |Column 1
+    |Column 2
+    |===
+    EOF
+
+    assert_xpath_equal xml, 'table-id', '//table/@id'
+  end
+
+  def test_table_no_id
+    xml = <<~EOF.chomp.to_dita
+    [cols="1, 1"]
+    |===
+    |Column 1 header|Column 2 header
+
+    |Column 1
+    |Column 2
+    |===
+    EOF
+
+    assert_xpath_count xml, 0, '//table/@id'
+  end
 end

--- a/test/test_ulist.rb
+++ b/test/test_ulist.rb
@@ -82,4 +82,67 @@ class UlistTest < Minitest::Test
     assert_xpath_equal xml, 'linux', '//ul[1]/li[1]/@platform'
     assert_xpath_equal xml, 'linux', '//ul[2]/li[1]/@platform'
   end
+
+  def test_unordered_list_id
+    xml = <<~EOF.chomp.to_dita
+    [#list-id]
+    .An unordered list title
+    * Item one
+    * Item two
+    EOF
+
+    assert_xpath_equal xml, 'list-id', '//ul/@id'
+    assert_xpath_count xml, 0, '//ul/li/@id'
+    assert_xpath_count xml, 0, '//p[@outputclass="title"]/@id'
+  end
+
+  def test_unordered_list_no_id
+    xml = <<~EOF.chomp.to_dita
+    * Item one
+    * Item two
+    EOF
+
+    assert_xpath_count xml, 0, '//ul/@id'
+  end
+
+  def test_unordered_list_item_id
+    doc = <<~EOF.chomp.parse_adoc
+    * Item one
+    * Item two
+
+    // A comment separates two lists
+
+    * Item one
+    +
+    Additional paragraph
+
+    * Item two
+    EOF
+
+    first_list = doc.blocks[0]
+    first_list.items[0].id = 'first-id'
+    second_list = doc.blocks[1]
+    second_list.items[0].id = 'second-id'
+    xml = doc.convert
+
+    assert_xpath_equal xml, 'first-id', '//ul[1]/li[1]/@id'
+    assert_xpath_equal xml, 'second-id', '//ul[2]/li[1]/@id'
+  end
+
+  def test_unordered_list_item_no_id
+    xml = <<~EOF.chomp.to_dita
+    * Item one
+    * Item two
+
+    // A comment separates two lists
+
+    * Item one
+    +
+    Additional paragraph
+
+    * Item two
+    EOF
+
+    assert_xpath_count xml, 0, '//ul/li/@id'
+  end
 end

--- a/test/test_verse.rb
+++ b/test/test_verse.rb
@@ -53,4 +53,24 @@ class VerseTest < Minitest::Test
 
     assert_xpath_equal xml, 'linux', '//lines/@platform'
   end
+
+  def test_verse_id
+    xml = <<~EOF.chomp.to_dita
+    [verse,id="verse-id"]
+    First line
+    Second line
+    EOF
+
+    assert_xpath_equal xml, 'verse-id', '//lines/@id'
+  end
+
+  def test_verse_no_id
+    xml = <<~EOF.chomp.to_dita
+    [verse]
+    First line
+    Second line
+    EOF
+
+    assert_xpath_count xml, 0, '//lines/@id'
+  end
 end

--- a/test/test_video.rb
+++ b/test/test_video.rb
@@ -80,4 +80,40 @@ class VideoTest < Minitest::Test
 
     assert_xpath_equal xml, 'linux', '//object/@platform'
   end
+
+  def test_video_id
+    xml = <<~EOF.chomp.to_dita
+    [#video-id]
+    video::video.mp4[]
+    EOF
+
+    assert_xpath_equal xml, 'video-id', '//object/@id'
+  end
+
+  def test_video_id_with_title
+    xml = <<~EOF.chomp.to_dita
+    [#video-id]
+    .Video title
+    video::video.mp4[]
+    EOF
+
+    assert_xpath_equal xml, 'video-id', '//object/@id'
+  end
+
+  def test_video_no_id
+    xml = <<~EOF.chomp.to_dita
+    video::video.mp4[]
+    EOF
+
+    assert_xpath_count xml, 0, '//object/@id'
+  end
+
+  def test_video_no_id_with_title
+    xml = <<~EOF.chomp.to_dita
+    .Video title
+    video::video.mp4[]
+    EOF
+
+    assert_xpath_count xml, 0, '//object/@id'
+  end
 end


### PR DESCRIPTION
Both DITA 1.3 and AsciiDoc allow most block and inline elements to have an optional ID. This pull request ensures that all elements that can have an ID assigned in AsciiDoc also propagate this ID to the DITA output.

### Example AsciiDoc code

```asciidoc
[#admonition-id]
TIP: This is a tip.
```

### Example DITA output

```xml
<note type="tip" id="admonition-id">This is a tip.</note>
```