### PR TITLE
Allow pre-processing of prepended files

### DIFF
--- a/lib/dita-topic/cli.rb
+++ b/lib/dita-topic/cli.rb
@@ -33,9 +33,9 @@ module AsciidoctorDitaTopic
       @attr = ['experimental']
       @opts = {
         :output => false,
-        :includes => true,
         :standalone => true,
-        :map => false
+        :map => false,
+        :no_includes => 0
       }
       @prep = []
       @name = name
@@ -72,8 +72,8 @@ module AsciidoctorDitaTopic
           @prep.append file
         end
 
-        opt.on('-I', '--no-includes', 'disable processing of include directives') do
-          @opts[:includes] = false
+        opt.on('-I', '--no-includes', 'disable processing of include directives; specify this option twice to also apply on prepended files') do
+          @opts[:no_includes] += 1
         end
 
         opt.separator ''
@@ -217,7 +217,8 @@ module AsciidoctorDitaTopic
         end
 
         prepended.gsub!(/^:_(?:mod-docs-content|content|module)-type:[ \t]+\S/, '//\&')
-        input.gsub!(Asciidoctor::IncludeDirectiveRx, '//\&') unless @opts[:includes]
+        prepended.gsub!(Asciidoctor::IncludeDirectiveRx, '//\&') if @opts[:no_includes] > 1
+        input.gsub!(Asciidoctor::IncludeDirectiveRx, '//\&') if @opts[:no_includes] > 0
 
         if @opts[:map]
           result = convert_map file, prepended + input, base_dir

--- a/lib/dita-topic/cli.rb
+++ b/lib/dita-topic/cli.rb
@@ -216,6 +216,7 @@ module AsciidoctorDitaTopic
           output   = @opts[:output] ? @opts[:output] : Pathname.new(file).sub_ext(suffix).to_s
         end
 
+        prepended.gsub!(/^:_(?:mod-docs-content|content|module)-type:[ \t]+\S/, '//\&')
         input.gsub!(Asciidoctor::IncludeDirectiveRx, '//\&') unless @opts[:includes]
 
         if @opts[:map]

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -10,9 +10,9 @@ class CliTest < Minitest::Test
 
     assert_includes attr, 'experimental'
     assert_equal false, opts[:output]
-    assert_equal true, opts[:includes]
     assert_equal true, opts[:standalone]
     assert_equal false, opts[:map]
+    assert_equal 0, opts[:no_includes]
     assert_equal [], prep
   end
 
@@ -190,14 +190,21 @@ class CliTest < Minitest::Test
     cli  = AsciidoctorDitaTopic::Cli.new 'script-name', ['-I']
     opts = cli.instance_variable_get :@opts
 
-    assert_equal false, opts[:includes]
+    assert_equal 1, opts[:no_includes]
   end
 
   def test_no_includes_long
     cli  = AsciidoctorDitaTopic::Cli.new 'script-name', ['--no-includes']
     opts = cli.instance_variable_get :@opts
 
-    assert_equal false, opts[:includes]
+    assert_equal 1, opts[:no_includes]
+  end
+
+  def test_no_includes_prepended
+    cli  = AsciidoctorDitaTopic::Cli.new 'script-name', ['-II']
+    opts = cli.instance_variable_get :@opts
+
+    assert_equal 2, opts[:no_includes]
   end
 
   def test_no_header_footer_short


### PR DESCRIPTION
When a prepended file contains its own `_mod-docs-content-type` attribute definition, this value takes precedent over the value defined in the actual file. Since this is not a desired behavior in any scenario, I added preprocessing to strip these content type definitions from prepended files.

In addition, I also added the ability to suppress include directives in the prepended files by providing the `-I`/`--no-includes` option twice:

```console
$ dita-topic -II -p attributes.adoc topic.adoc
```