### PR TITLE
Update the list to currently supported versions of Ruby

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['3.4', '3.2', '3.0']
+        ruby-version: ['3.4', '3.3', '3.2']
 
     steps:
     - uses: actions/checkout@v4

--- a/asciidoctor-dita-topic.gemspec
+++ b/asciidoctor-dita-topic.gemspec
@@ -37,5 +37,6 @@ Gem::Specification.new do |s|
   # Development gems:
   s.add_development_dependency 'rake', '~> 13.3', '>= 13.3.1'
   s.add_development_dependency 'minitest', '~> 6.0', '>= 6.0.2'
+  s.add_development_dependency 'minitest-mock', '~> 5.27'
   s.add_development_dependency 'rexml', '~> 3.4', '>= 3.4.4'
 end

--- a/asciidoctor-dita-topic.gemspec
+++ b/asciidoctor-dita-topic.gemspec
@@ -32,10 +32,10 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.0'
 
   # Required gems:
-  s.add_runtime_dependency 'asciidoctor', '~> 2.0', '>= 2.0.0'
+  s.add_runtime_dependency 'asciidoctor', '~> 2.0', '>= 2.0.26'
 
   # Development gems:
-  s.add_development_dependency 'rake', '~> 12.3.0'
-  s.add_development_dependency 'minitest', '~> 5.22.0'
-  s.add_development_dependency 'rexml', '~> 3.2.6'
+  s.add_development_dependency 'rake', '~> 13.3', '>= 13.3.1'
+  s.add_development_dependency 'minitest', '~> 6.0', '>= 6.0.2'
+  s.add_development_dependency 'rexml', '~> 3.4', '>= 3.4.4'
 end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -1,4 +1,5 @@
 require 'minitest/autorun'
+require 'minitest/mock'
 require_relative '../lib/dita-topic/cli'
 
 class CliTest < Minitest::Test


### PR DESCRIPTION
This pull requests updates the list of Ruby versions according to the official [maintenance status page](https://www.ruby-lang.org/en/downloads/branches/). Note that Asciidoctor does not seem to support Ruby 4.0 yet, so I do not test on it yet.