### PR TITLE
Remove empty `<ph>` elements with metadata attributes

### DIFF
--- a/lib/dita-topic/cli.rb
+++ b/lib/dita-topic/cli.rb
@@ -149,6 +149,8 @@ module AsciidoctorDitaTopic
 
         result = convert_topic prepended + input, base_dir
 
+        result.gsub!(/<ph (?:(?:platform|product|audience|otherprops)="[^"]+" ?)+><\/ph> */, '')
+
         if output == $stdout
           $stdout.write result
         else


### PR DESCRIPTION
AsciiDoc does not have a native syntax to assign a role to list items, description list items, or table rows from AsciiDoc source. To work around this problem, `dita-topic` adds support for the following syntax:

```asciidoc
* [.platform:linux.platform:mac]#{empty}# A list item only relevant for Linux and macOS.
```

This pull request removes the leftover `<ph>` elements from the generated output when the CLI is used:

```xml
<ph platform="linux mac"></ph>
```