### PR TITLE
Add the `-M`/`--no-semantic-markup` option

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -341,6 +341,6 @@ Thematic breaks not supported in DITA:: Asciidoc allows you to use `'''`, `---`,
 [#copyright]
 == Copyright
 
-Copyright (C) 2024, 2025 Jaromir Hradilek
+Copyright (C) 2024–2026 Jaromir Hradilek
 
 This program is free software, released under the terms of the link:LICENSE[MIT license]. It is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--- a/README.adoc
+++ b/README.adoc
@@ -133,7 +133,7 @@ To enable processing of author lines as metadata, run the `dita-topic` command w
 $ **dita-topic -l _your_file_.adoc**
 ....
 
-If you prefer to use Asciidoctor directly, set the value of the `dita-topic-authors` to `on`:
+If you prefer to use Asciidoctor directly, set the value of the `dita-topic-authors` attribute to `on`:
 
 [literal,subs="+quotes"]
 ....
@@ -157,7 +157,7 @@ To disable this behavior, run the `dita-topic` command with the `-T` option:
 $ **dita-topic -T _your_file_.adoc**
 ....
 
-If you prefer to use Asciidoctor directly, set the value of the `dita-topic-titles` to `off`:
+If you prefer to use Asciidoctor directly, set the value of the `dita-topic-titles` attribute to `off`:
 
 [literal,subs="+quotes"]
 ....
@@ -176,7 +176,7 @@ To disable this behavior, run the `dita-topic` command with the `-C` option:
 $ **dita-topic -C _your_file_.adoc**
 ....
 
-If you prefer to use Asciidoctor directly, set the value of the `dita-topic-callouts` to `off`:
+If you prefer to use Asciidoctor directly, set the value of the `dita-topic-callouts` attribute to `off`:
 
 [literal,subs="+quotes"]
 ....
@@ -260,6 +260,20 @@ For example, to describe a file name, use the following AsciiDoc markup:
 Read the [filename]`/etc/passwd` file to see the complete list of
 available user accounts.
 ----
+
+To disable this behavior, for example when the source files do not annotate semantic markup consistently, run the `dita-topic` command with the `-M` option:
+
+[literal,subs="+quotes"]
+....
+$ **dita-topic -M _your_file_.adoc**
+....
+
+If you prefer to use Asciidoctor directly, set the value of the `dita-topic-semantic` attribute to `off`:
+
+[literal,subs="+quotes"]
+....
+$ **asciidoctor -r dita-topic -b dita-topic -a dita-topic-semantic=off _your_file_.adoc**
+....
 
 [#metadata]
 === Adding metadata

--- a/lib/dita-topic.rb
+++ b/lib/dita-topic.rb
@@ -1,5 +1,5 @@
 # A custom AsciiDoc converter that generates individual DITA topics
-# Copyright (C) 2024, 2025 Jaromir Hradilek
+# Copyright (C) 2024-2026 Jaromir Hradilek
 
 # MIT License
 #
@@ -38,6 +38,9 @@ class DitaTopic < Asciidoctor::Converter::Base
     # Disable the author line by default:
     @authors_allowed = false
 
+    # Enable processing of semantic markup by default:
+    @semantic_allowed = true
+
     # Enable callouts by default:
     @callouts_allowed = true
 
@@ -54,6 +57,9 @@ class DitaTopic < Asciidoctor::Converter::Base
   def convert_document node
     # Check if the author line is enabled:
     @authors_allowed = true if (node.attr 'dita-topic-authors') == 'on'
+
+    # Check if semantic markup is enabled:
+    @semantic_allowed = false if (node.attr 'dita-topic-semantic') == 'off'
 
     # Check if callouts are enabled:
     @callouts_allowed = false if (node.attr 'dita-topic-callouts') == 'off'
@@ -463,8 +469,8 @@ class DitaTopic < Asciidoctor::Converter::Base
       # Set the default element value:
       element = 'codeph'
 
-      # Check if the role is provided:
-      if node.role
+      # Check if semantic markup is enabled and the role is provided:
+      if @semantic_allowed and node.role
         # Define supported roles:
         semantic_markup = {
           'command'   => 'cmdname',

--- a/lib/dita-topic/cli.rb
+++ b/lib/dita-topic/cli.rb
@@ -85,6 +85,10 @@ module AsciidoctorDitaTopic
           @attr.append 'dita-topic-callouts=off'
         end
 
+        opt.on('-M', '--no-semantic-markup', 'disable processing of semantic markup') do
+          @attr.append 'dita-topic-semantic=off'
+        end
+
         opt.on('-S', '--no-sidebars', 'disable processing of sidebars') do
           @attr.append 'dita-topic-sidebars=off'
         end

--- a/lib/dita-topic/version.rb
+++ b/lib/dita-topic/version.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Jaromir Hradilek
+# Copyright (C) 2025, 2026 Jaromir Hradilek
 
 # MIT License
 #

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -251,6 +251,17 @@ class CliTest < Minitest::Test
     assert_includes cli.instance_variable_get(:@attr), 'dita-topic-callouts=off'
   end
 
+  def test_no_semantic_markup_short
+    cli  = AsciidoctorDitaTopic::Cli.new 'script-name', ['-M']
+    assert_includes cli.instance_variable_get(:@attr), 'dita-topic-semantic=off'
+  end
+
+  def test_no_semantic_markup_long
+    cli  = AsciidoctorDitaTopic::Cli.new 'script-name', ['--no-semantic-markup']
+    assert_includes cli.instance_variable_get(:@attr), 'dita-topic-semantic=off'
+  end
+
+
   def test_no_sidebars_short
     cli  = AsciidoctorDitaTopic::Cli.new 'script-name', ['-S']
     assert_includes cli.instance_variable_get(:@attr), 'dita-topic-sidebars=off'

--- a/test/test_inline_quoted.rb
+++ b/test/test_inline_quoted.rb
@@ -72,6 +72,24 @@ class InlineQuotedTest < Minitest::Test
     assert_xpath_equal xml, 'a variable', '//li[5]/varname/text()'
   end
 
+  def test_semantic_markup_off
+    xml = <<~EOF.chomp.to_dita
+    :dita-topic-semantic: off
+    * [command]`a command`
+    * [directory]`a directory name`
+    * [filename]`a file name`
+    * [option]`an option`
+    * [variable]`a variable`
+    EOF
+
+    assert_xpath_count xml, 5, '//li'
+    assert_xpath_equal xml, 'a command', '//li[1]/codeph/text()'
+    assert_xpath_equal xml, 'a directory name', '//li[2]/codeph/text()'
+    assert_xpath_equal xml, 'a file name', '//li[3]/codeph/text()'
+    assert_xpath_equal xml, 'an option', '//li[4]/codeph/text()'
+    assert_xpath_equal xml, 'a variable', '//li[5]/codeph/text()'
+  end
+
   def test_text_span
     xml = <<~EOF.chomp.to_dita
     A line with #inline text span#.


### PR DESCRIPTION
Under certain circumstances, the presence of semantic markup can lead to invalid DITA markup if such an element appears in a context that does not allow it. To work around this problem, I added the `-M`/`--no-semantic-markup` option which disables processing of semantic markup:

```console
$ echo '[filename]`/path/to/file.txt`' | dita-topic | grep file.txt
<p><filepath>/path/to/file.txt</filepath></p>
```
```console
$ echo '[filename]`/path/to/file.txt`' | dita-topic -M | grep file.txt
<p><codeph>/path/to/file.txt</codeph></p>
```